### PR TITLE
Improve screencast performance by switching to OSX AVFoundation screen capture

### DIFF
--- a/OSXvnc-server/AVSampleBufferHolder.h
+++ b/OSXvnc-server/AVSampleBufferHolder.h
@@ -1,0 +1,19 @@
+//
+//  AVSampleBuffer.h
+//  OSXvnc-server
+//
+//  Created by Mykola Mokhnach on 19.01.19.
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AVSampleBufferHolder : NSObject
+
+@property (assign, nonatomic, nullable) CMSampleBufferRef sampleBuffer;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OSXvnc-server/AVSampleBufferHolder.h
+++ b/OSXvnc-server/AVSampleBufferHolder.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AVSampleBufferHolder : NSObject
 
-@property (assign, nonatomic, nullable) CMSampleBufferRef sampleBuffer;
+@property (assign, nonatomic, nullable) IOSurfaceRef sampleBuffer;
 @property (nonatomic) uint64_t timestamp;
 
 @end

--- a/OSXvnc-server/AVSampleBufferHolder.h
+++ b/OSXvnc-server/AVSampleBufferHolder.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AVSampleBufferHolder : NSObject
 
-@property (nonatomic, nullable) IOSurfaceRef sampleBuffer;
+@property (nonatomic, nullable, assign) IOSurfaceRef sampleBuffer;
 @property (nonatomic) uint64_t timestamp;
 
 @end

--- a/OSXvnc-server/AVSampleBufferHolder.h
+++ b/OSXvnc-server/AVSampleBufferHolder.h
@@ -1,8 +1,9 @@
 //
 //  AVSampleBuffer.h
-//  OSXvnc-server
+//  OSXvnc
 //
 //  Created by Mykola Mokhnach on 19.01.19.
+//  Copyright (c) 2019 Sauce Labs Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/OSXvnc-server/AVSampleBufferHolder.h
+++ b/OSXvnc-server/AVSampleBufferHolder.h
@@ -1,5 +1,5 @@
 //
-//  AVSampleBuffer.h
+//  AVSampleBufferHolder.h
 //  OSXvnc
 //
 //  Created by Mykola Mokhnach on 19.01.19.

--- a/OSXvnc-server/AVSampleBufferHolder.h
+++ b/OSXvnc-server/AVSampleBufferHolder.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AVSampleBufferHolder : NSObject
 
-@property (assign, nonatomic, nullable) IOSurfaceRef sampleBuffer;
+@property (nonatomic, nullable) IOSurfaceRef sampleBuffer;
 @property (nonatomic) uint64_t timestamp;
 
 @end

--- a/OSXvnc-server/AVSampleBufferHolder.h
+++ b/OSXvnc-server/AVSampleBufferHolder.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AVSampleBufferHolder : NSObject
 
 @property (assign, nonatomic, nullable) CMSampleBufferRef sampleBuffer;
+@property (nonatomic) uint64_t timestamp;
 
 @end
 

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -1,5 +1,5 @@
 //
-//  AVSampleBuffer.m
+//  AVSampleBufferHolder.m
 //  OSXvnc
 //
 //  Created by Mykola Mokhnach on 19.01.19.

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -1,0 +1,34 @@
+//
+//  AVSampleBuffer.m
+//  OSXvnc-server
+//
+//  Created by Mykola Mokhnach on 19.01.19.
+//
+
+#import "AVSampleBufferHolder.h"
+
+
+@implementation AVSampleBufferHolder
+
+- (void)dealloc {
+  if (_sampleBuffer != nil) {
+    CFRelease(_sampleBuffer);
+  }
+
+  [super dealloc];
+}
+
+- (void)setSampleBuffer:(CMSampleBufferRef)sampleBuffer {
+  if (_sampleBuffer != nil) {
+    CFRelease(_sampleBuffer);
+    _sampleBuffer = nil;
+  }
+
+  _sampleBuffer = sampleBuffer;
+
+  if (nil != sampleBuffer) {
+    CFRetain(sampleBuffer);
+  }
+}
+
+@end

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -29,7 +29,7 @@
     [super dealloc];
 }
 
-- (void)setSampleBuffer:(CMSampleBufferRef)sampleBuffer {
+- (void)setSampleBuffer:(IOSurfaceRef)sampleBuffer {
     if (nil != _sampleBuffer) {
         CFRelease(_sampleBuffer);
         _sampleBuffer = nil;

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -11,6 +11,16 @@
 
 @implementation AVSampleBufferHolder
 
+@synthesize timestamp = _timestamp;
+
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _timestamp = 0;
+  }
+  return self;
+}
+
 - (void)dealloc {
   if (nil != _sampleBuffer) {
     CFRelease(_sampleBuffer);

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -1,8 +1,9 @@
 //
 //  AVSampleBuffer.m
-//  OSXvnc-server
+//  OSXvnc
 //
 //  Created by Mykola Mokhnach on 19.01.19.
+//  Copyright (c) 2019 Sauce Labs Inc. All rights reserved.
 //
 
 #import "AVSampleBufferHolder.h"
@@ -11,7 +12,7 @@
 @implementation AVSampleBufferHolder
 
 - (void)dealloc {
-  if (_sampleBuffer != nil) {
+  if (nil != _sampleBuffer) {
     CFRelease(_sampleBuffer);
   }
 
@@ -19,13 +20,12 @@
 }
 
 - (void)setSampleBuffer:(CMSampleBufferRef)sampleBuffer {
-  if (_sampleBuffer != nil) {
+  if (nil != _sampleBuffer) {
     CFRelease(_sampleBuffer);
     _sampleBuffer = nil;
   }
 
   _sampleBuffer = sampleBuffer;
-
   if (nil != sampleBuffer) {
     CFRetain(sampleBuffer);
   }

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -21,7 +21,6 @@
 
 - (void)dealloc {
     if (nil != _sampleBuffer) {
-        IOSurfaceDecrementUseCount(_sampleBuffer);
         CFRelease(_sampleBuffer);
     }
 
@@ -30,7 +29,6 @@
 
 - (void)setSampleBuffer:(IOSurfaceRef)sampleBuffer {
     if (nil != _sampleBuffer) {
-        IOSurfaceDecrementUseCount(_sampleBuffer);
         CFRelease(_sampleBuffer);
         _sampleBuffer = nil;
     }
@@ -38,7 +36,6 @@
     _sampleBuffer = sampleBuffer;
     if (nil != sampleBuffer) {
         CFRetain(sampleBuffer);
-        IOSurfaceIncrementUseCount(sampleBuffer);
     }
 }
 

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -11,8 +11,6 @@
 
 @implementation AVSampleBufferHolder
 
-@synthesize timestamp = _timestamp;
-
 - (instancetype)init
 {
     if ((self = [super init])) {

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -8,12 +8,12 @@
 
 #import "AVSampleBufferHolder.h"
 
-
 @implementation AVSampleBufferHolder
 
 - (instancetype)init
 {
     if ((self = [super init])) {
+        _sampleBuffer = nil;
         _timestamp = 0;
     }
     return self;
@@ -21,6 +21,7 @@
 
 - (void)dealloc {
     if (nil != _sampleBuffer) {
+        IOSurfaceDecrementUseCount(_sampleBuffer);
         CFRelease(_sampleBuffer);
     }
 
@@ -29,6 +30,7 @@
 
 - (void)setSampleBuffer:(IOSurfaceRef)sampleBuffer {
     if (nil != _sampleBuffer) {
+        IOSurfaceDecrementUseCount(_sampleBuffer);
         CFRelease(_sampleBuffer);
         _sampleBuffer = nil;
     }
@@ -36,6 +38,7 @@
     _sampleBuffer = sampleBuffer;
     if (nil != sampleBuffer) {
         CFRetain(sampleBuffer);
+        IOSurfaceIncrementUseCount(sampleBuffer);
     }
 }
 

--- a/OSXvnc-server/AVSampleBufferHolder.m
+++ b/OSXvnc-server/AVSampleBufferHolder.m
@@ -15,30 +15,30 @@
 
 - (instancetype)init
 {
-  if ((self = [super init])) {
-    _timestamp = 0;
-  }
-  return self;
+    if ((self = [super init])) {
+        _timestamp = 0;
+    }
+    return self;
 }
 
 - (void)dealloc {
-  if (nil != _sampleBuffer) {
-    CFRelease(_sampleBuffer);
-  }
+    if (nil != _sampleBuffer) {
+        CFRelease(_sampleBuffer);
+    }
 
-  [super dealloc];
+    [super dealloc];
 }
 
 - (void)setSampleBuffer:(CMSampleBufferRef)sampleBuffer {
-  if (nil != _sampleBuffer) {
-    CFRelease(_sampleBuffer);
-    _sampleBuffer = nil;
-  }
+    if (nil != _sampleBuffer) {
+        CFRelease(_sampleBuffer);
+        _sampleBuffer = nil;
+    }
 
-  _sampleBuffer = sampleBuffer;
-  if (nil != sampleBuffer) {
-    CFRetain(sampleBuffer);
-  }
+    _sampleBuffer = sampleBuffer;
+    if (nil != sampleBuffer) {
+        CFRetain(sampleBuffer);
+    }
 }
 
 @end

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -11,6 +11,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern const int32_t MIN_FPS;
+extern const int32_t MAX_FPS;
+extern const size_t BYTES_PER_PIXEL;
+
 @interface AVScreenCapture : NSObject
 
 @property (readonly) CGDirectDisplayID displayID;

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -15,7 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) CGDirectDisplayID displayID;
 
-- (void)startForDisplay:(CGDirectDisplayID)displayID;
+- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID;
+- (void)start;
 - (nullable CMSampleBufferRef)lastFrame;
 - (void)stop;
 

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -3,7 +3,7 @@
 //  OSXvnc
 //
 //  Created by Mykola Mokhnach on Mon Jan 14 2019.
-//  Copyright (c) 2019 Sauce Labds Inc. All rights reserved.
+//  Copyright (c) 2019 Sauce Labs Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AVScreenCapture : NSObject
 
 @property (readonly) CGDirectDisplayID displayID;
+@property (readonly) CGFloat scaleFactor;
 
 - (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor;
 - (void)start;

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -17,9 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) CGFloat scaleFactor;
 
 - (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor;
-- (void)start;
+- (void)startWithFps:(int32_t)fps;
 - (nullable CMSampleBufferRef)lastFrame;
-- (nullable CMSampleBufferRef)frameWithTimeout:(NSTimeInterval)timeout;
+- (nullable CMSampleBufferRef)nextFrameWithTimeout:(NSTimeInterval)timeout;
 - (void)stop;
 
 @end

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -18,12 +18,13 @@ extern const size_t BYTES_PER_PIXEL;
 @interface AVScreenCapture : NSObject
 
 @property (readonly) CGDirectDisplayID displayID;
-@property (readonly) CGFloat scaleFactor;
 
-- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor;
-- (void)startWithFps:(int32_t)fps;
-- (BOOL)retrieveLastFrame:(CMSampleBufferRef *)frame timestamp:(nullable uint64_t *)timestamp;
-- (BOOL)retrieveNextFrame:(CMSampleBufferRef *)frame timestamp:(nullable uint64_t *)timestamp timeout:(NSTimeInterval)timeout;
+- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID;
+- (BOOL)startWithWidth:(size_t)width
+                height:(size_t)height
+       refreshCallback:(CGScreenRefreshCallback)refreshCallback;
+- (BOOL)retrieveLastFrame:(IOSurfaceRef *)surface
+                timestamp:(nullable uint64_t *)timestamp;
 - (void)stop;
 
 @end

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) CGDirectDisplayID displayID;
 
-- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID;
+- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor;
 - (void)start;
 - (nullable CMSampleBufferRef)lastFrame;
 - (void)stop;

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -11,7 +11,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern const size_t BYTES_PER_PIXEL;
+#define DISPLAY_FPS 30
+#define BYTES_PER_PIXEL 4
 
 @interface AVScreenCapture : NSObject
 

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -22,8 +22,8 @@ extern const size_t BYTES_PER_PIXEL;
 
 - (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor;
 - (void)startWithFps:(int32_t)fps;
-- (nullable CMSampleBufferRef)lastFrame;
-- (nullable CMSampleBufferRef)nextFrameWithTimeout:(NSTimeInterval)timeout;
+- (BOOL)retrieveLastFrame:(CMSampleBufferRef *)frame timestamp:(uint64_t *)timestamp;
+- (BOOL)retrieveNextFrame:(CMSampleBufferRef *)frame timestamp:(uint64_t *)timestamp timeout:(NSTimeInterval)timeout;
 - (void)stop;
 
 @end

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor;
 - (void)start;
 - (nullable CMSampleBufferRef)lastFrame;
+- (nullable CMSampleBufferRef)frameWithTimeout:(NSTimeInterval)timeout;
 - (void)stop;
 
 @end

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -1,0 +1,24 @@
+//
+//  AVScreenCapture.h
+//  OSXvnc
+//
+//  Created by Mykola Mokhnach on Mon Jan 14 2019.
+//  Copyright (c) 2019 Sauce Labds Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AVScreenCapture : NSObject
+
+@property (readonly) CGDirectDisplayID displayID;
+
+- (void)startForDisplay:(CGDirectDisplayID)displayID;
+- (nullable CMSampleBufferRef)lastFrame;
+- (void)stop;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -11,18 +11,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern const int32_t MIN_FPS;
-extern const int32_t MAX_FPS;
 extern const size_t BYTES_PER_PIXEL;
 
 @interface AVScreenCapture : NSObject
 
 @property (readonly) CGDirectDisplayID displayID;
 
-- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID;
+- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID
+                  refreshCallback:(CGScreenRefreshCallback)refreshCallback;
 - (BOOL)startWithWidth:(size_t)width
-                height:(size_t)height
-       refreshCallback:(CGScreenRefreshCallback)refreshCallback;
+                height:(size_t)height;
 - (BOOL)retrieveLastFrame:(IOSurfaceRef *)surface
                 timestamp:(nullable uint64_t *)timestamp;
 - (void)stop;

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -22,8 +22,8 @@ extern const size_t BYTES_PER_PIXEL;
 
 - (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor;
 - (void)startWithFps:(int32_t)fps;
-- (BOOL)retrieveLastFrame:(CMSampleBufferRef *)frame timestamp:(uint64_t *)timestamp;
-- (BOOL)retrieveNextFrame:(CMSampleBufferRef *)frame timestamp:(uint64_t *)timestamp timeout:(NSTimeInterval)timeout;
+- (BOOL)retrieveLastFrame:(CMSampleBufferRef *)frame timestamp:(nullable uint64_t *)timestamp;
+- (BOOL)retrieveNextFrame:(CMSampleBufferRef *)frame timestamp:(nullable uint64_t *)timestamp timeout:(NSTimeInterval)timeout;
 - (void)stop;
 
 @end

--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -22,7 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
                   refreshCallback:(CGScreenRefreshCallback)refreshCallback;
 - (BOOL)startWithWidth:(size_t)width
                 height:(size_t)height;
-- (BOOL)retrieveLastFrame:(IOSurfaceRef *)surface
+- (BOOL)retrieveLastFrame:(char **)frameData
+               dataLength:(nullable size_t *)dataLength
                 timestamp:(nullable uint64_t *)timestamp;
 - (void)stop;
 

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -134,8 +134,12 @@ const size_t BYTES_PER_PIXEL = 4;
         return NO;
     }
 
-    *frame = buffer;
-    *timestamp = stamp;
+    if (frame) {
+        *frame = buffer;
+    }
+    if (timestamp) {
+        *timestamp = stamp;
+    }
     return YES;
 }
 

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -24,13 +24,14 @@
 
 @synthesize displayID = _displayID;
 
-- (instancetype)init
+- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID
 {
   if ((self = [super init])) {
     _session = nil;
     _output = nil;
     _input = nil;
     _sessionQueue = NULL;
+    _displayID = displayID;
     _sampleBufferHolder = [[AVSampleBufferHolder alloc] init];
   }
   return self;
@@ -50,17 +51,19 @@
   [super dealloc];
 }
 
-- (void)startForDisplay:(CGDirectDisplayID)displayID
+- (void)start
 {
+  if (nil != self.session) {
+    return;
+  }
+
   [self stop];
 
   self.session = [[AVCaptureSession alloc] init];
 
-  _displayID = displayID;
-  self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:displayID];
+  self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:self.displayID];
   self.input.capturesCursor = NO;
   [self.session addInput:self.input];
-
   self.output = [[AVCaptureVideoDataOutput alloc] init];
   self.output.videoSettings = @{
     (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -17,6 +17,7 @@
 @property (nonatomic, retain, nullable) AVCaptureScreenInput *input;
 @property (nonatomic, retain) AVSampleBufferHolder *sampleBufferHolder;
 @property dispatch_queue_t sessionQueue;
+@property CGFloat scaleFactor;
 
 @end
 
@@ -24,7 +25,7 @@
 
 @synthesize displayID = _displayID;
 
-- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID
+- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor
 {
   if ((self = [super init])) {
     _session = nil;
@@ -32,6 +33,7 @@
     _input = nil;
     _sessionQueue = NULL;
     _displayID = displayID;
+    _scaleFactor = scaleFactor;
     _sampleBufferHolder = [[AVSampleBufferHolder alloc] init];
   }
   return self;
@@ -63,6 +65,7 @@
 
   self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:self.displayID];
   self.input.capturesCursor = NO;
+  self.input.scaleFactor = self.scaleFactor;
   [self.session addInput:self.input];
   self.output = [[AVCaptureVideoDataOutput alloc] init];
   self.output.videoSettings = @{

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -18,32 +18,20 @@ const size_t BYTES_PER_PIXEL = 4;
 
 @interface AVScreenCapture() <AVCaptureVideoDataOutputSampleBufferDelegate>
 
-@property (nonatomic, retain, nullable) AVCaptureSession *session;
-@property (nonatomic, retain, nullable) AVCaptureVideoDataOutput *output;
-@property (nonatomic, retain, nullable) AVCaptureScreenInput *input;
 @property (nonatomic, retain) AVSampleBufferHolder *sampleBufferHolder;
-@property (nonatomic) dispatch_queue_t sessionQueue;
-@property (nonatomic, nullable) dispatch_semaphore_t nextFrameSemaphore;
-@property (nonatomic) BOOL isWaitingForNextFrame;
+@property (nonatomic) CGDisplayStreamRef displayStream;
 
 @end
 
 @implementation AVScreenCapture
 
 @synthesize displayID = _displayID;
-@synthesize scaleFactor = _scaleFactor;
 
-- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor
+- (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID
 {
     if ((self = [super init])) {
-        _session = nil;
-        _output = nil;
-        _input = nil;
-        _sessionQueue = NULL;
         _displayID = displayID;
-        _scaleFactor = scaleFactor;
-        _nextFrameSemaphore = NULL;
-        _isWaitingForNextFrame = NO;
+        _displayStream = nil;
         _sampleBufferHolder = [[AVSampleBufferHolder alloc] init];
     }
     return self;
@@ -55,126 +43,90 @@ const size_t BYTES_PER_PIXEL = 4;
     [_sampleBufferHolder release];
     _sampleBufferHolder = nil;
 
-    if (NULL != _sessionQueue) {
-        dispatch_release(_sessionQueue);
-        _sessionQueue = NULL;
-    }
-
     [super dealloc];
 }
 
-- (void)startWithFps:(int32_t)fps
+- (BOOL)startWithWidth:(size_t)width height:(size_t)height refreshCallback:(CGScreenRefreshCallback)refreshCallback
 {
-    if (nil != self.session) {
-        return;
+    if (nil != self.displayStream) {
+        return YES;
     }
 
-    [self stop];
+    CGDisplayStreamFrameAvailableHandler handler = ^(CGDisplayStreamFrameStatus status, uint64_t displayTime,
+                                                     IOSurfaceRef __nullable frameSurface,
+                                                     CGDisplayStreamUpdateRef __nullable updateRef) {
+        if (kCGDisplayStreamFrameStatusStopped == status) {
+            if (self.displayStream) {
+                CFRelease(self.displayStream);
+                self.displayStream = nil;
+            }
+        }
+        // Only pay attention to frame updates.
+        if (status != kCGDisplayStreamFrameStatusFrameComplete || !frameSurface || !updateRef) {
+            return;
+        }
+        @synchronized (self.sampleBufferHolder) {
+            self.sampleBufferHolder.sampleBuffer = frameSurface;
+            self.sampleBufferHolder.timestamp = displayTime;
+        }
+        size_t count = 0;
+        const CGRect* rects = CGDisplayStreamUpdateGetRects(updateRef, kCGDisplayStreamUpdateDirtyRects, &count);
+        if (count > 0) {
+            refreshCallback((uint32_t)count, rects, nil);
+        }
+    };
 
-    self.session = [[AVCaptureSession alloc] init];
-
-    self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:self.displayID];
-    self.input.capturesCursor = NO;
-    self.input.scaleFactor = self.scaleFactor;
-    self.input.minFrameDuration = CMTimeMake(1, MAX(MIN_FPS, MIN(fps, MAX_FPS)));
-    [self.session addInput:self.input];
-    self.output = [[AVCaptureVideoDataOutput alloc] init];
-    self.output.videoSettings = @{
-                                  (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)
-                                  };
-    self.output.alwaysDiscardsLateVideoFrames = YES;
-    [self.session addOutput:self.output];
-    dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, DISPATCH_QUEUE_PRIORITY_HIGH);
-    self.sessionQueue = dispatch_queue_create("de.uni-mannheim.VineServer.avscreencapture", queueAttributes);
-    [self.output setSampleBufferDelegate:self queue:self.sessionQueue];
-
-    self.nextFrameSemaphore = dispatch_semaphore_create(0);
-
-    [self.session startRunning];
+    CFDictionaryRef propertiesDict = CFDictionaryCreate(kCFAllocatorDefault,
+                                                         (const void* []){kCGDisplayStreamShowCursor},
+                                                         (const void* []){kCFBooleanFalse},
+                                                         1,
+                                                         &kCFTypeDictionaryKeyCallBacks,
+                                                         &kCFTypeDictionaryValueCallBacks);
+    self.displayStream = CGDisplayStreamCreate(self.displayID, width, height, 'BGRA', propertiesDict, handler);
+    CFRelease(propertiesDict);
+    if (self.displayStream) {
+        CGError error = CGDisplayStreamStart(self.displayStream);
+        if (error != kCGErrorSuccess) {
+            self.displayStream = nil;
+            return NO;
+        }
+        CFRunLoopSourceRef source = CGDisplayStreamGetRunLoopSource(self.displayStream);
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
+        return YES;
+    }
+    return NO;
 }
 
 - (void)stop
 {
-    if (nil == self.session) {
+    if (nil == self.displayStream) {
         return;
     }
 
-    [self.session stopRunning];
-    [self.session removeInput:self.input];
-    [self.input release];
-    self.input = nil;
-    [self.session removeOutput:self.output];
-    [self.output release];
-    self.output = nil;
-    [self.session release];
-    self.session = nil;
-
-    if (NULL != self.nextFrameSemaphore) {
-        dispatch_release(self.nextFrameSemaphore);
-        self.nextFrameSemaphore = NULL;
-    }
+    CFRunLoopSourceRef source = CGDisplayStreamGetRunLoopSource(self.displayStream);
+    CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
+    CGDisplayStreamStop(self.displayStream);
 }
 
-- (BOOL)retrieveLastFrame:(CMSampleBufferRef *)frame timestamp:(uint64_t *)timestamp
+- (BOOL)retrieveLastFrame:(IOSurfaceRef *)surface timestamp:(uint64_t *)timestamp
 {
-    if (nil == self.session) {
+    if (nil == self.displayStream) {
         return NO;
     }
 
-    __block CMSampleBufferRef buffer = nil;
-    __block uint64_t stamp = 0;
-    dispatch_sync(self.sessionQueue, ^{
-        buffer = self.sampleBufferHolder.sampleBuffer;
-        stamp = self.sampleBufferHolder.timestamp;
-        if (nil != buffer) {
-            CFRetain(buffer);
+    @synchronized (self.sampleBufferHolder) {
+        if (surface) {
+            *surface = self.sampleBufferHolder.sampleBuffer;
         }
-    });
-    if (nil == buffer) {
+        if (timestamp) {
+            *timestamp = self.sampleBufferHolder.timestamp;
+        }
+    }
+    if (nil == *surface) {
         return NO;
     }
-
-    if (frame) {
-        *frame = buffer;
-    }
-    if (timestamp) {
-        *timestamp = stamp;
-    }
+    CFRetain(*surface);
     return YES;
-}
-
-- (BOOL)retrieveNextFrame:(CMSampleBufferRef *)frame timestamp:(uint64_t *)timestamp timeout:(NSTimeInterval)timeout
-{
-    if (nil == self.session) {
-        return NO;
-    }
-
-    @synchronized (self) {
-        self.isWaitingForNextFrame = YES;
-    }
-    BOOL didFrameArrive = 0 == dispatch_semaphore_wait(self.nextFrameSemaphore,
-                                                       dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)));
-    @synchronized (self) {
-        self.isWaitingForNextFrame = NO;
-    }
-    if (!didFrameArrive) {
-        return NO;
-    }
-
-    return [self retrieveLastFrame:frame timestamp:timestamp];
-}
-
-- (void)captureOutput:(AVCaptureOutput *)output
-didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
-       fromConnection:(AVCaptureConnection *)connection {
-    self.sampleBufferHolder.sampleBuffer = sampleBuffer;
-    self.sampleBufferHolder.timestamp = mach_absolute_time();
-    @synchronized (self) {
-        if (!self.isWaitingForNextFrame) {
-            return;
-        }
-    }
-    dispatch_semaphore_signal(self.nextFrameSemaphore);
 }
 
 @end

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -8,8 +8,6 @@
 
 #import "AVScreenCapture.h"
 
-#import <AppKit/AppKit.h>
-#import <mach/mach_time.h>
 #import "AVSampleBufferHolder.h"
 
 const size_t BYTES_PER_PIXEL = 4;

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -1,0 +1,114 @@
+//
+//  AVScreenCapture.h
+//  OSXvnc
+//
+//  Created by Mykola Mokhnach on Mon Jan 14 2019.
+//  Copyright (c) 2019 Sauce Labds Inc. All rights reserved.
+//
+
+#import "AVScreenCapture.h"
+#import <AppKit/AppKit.h>
+#import "AVSampleBufferHolder.h"
+
+@interface AVScreenCapture() <AVCaptureVideoDataOutputSampleBufferDelegate>
+
+@property (nonatomic, retain, nullable) AVCaptureSession *session;
+@property (nonatomic, retain, nullable) AVCaptureVideoDataOutput *output;
+@property (nonatomic, retain, nullable) AVCaptureScreenInput *input;
+@property (nonatomic, retain) AVSampleBufferHolder *sampleBufferHolder;
+@property dispatch_queue_t sessionQueue;
+
+@end
+
+@implementation AVScreenCapture
+
+@synthesize displayID = _displayID;
+
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _session = nil;
+    _output = nil;
+    _input = nil;
+    _sessionQueue = NULL;
+    _sampleBufferHolder = [[AVSampleBufferHolder alloc] init];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [self stop];
+
+  [_sampleBufferHolder release];
+  _sampleBufferHolder = nil;
+
+  if (NULL != _sessionQueue) {
+    dispatch_release(_sessionQueue);
+    _sessionQueue = NULL;
+  }
+
+  [super dealloc];
+}
+
+- (void)startForDisplay:(CGDirectDisplayID)displayID
+{
+  [self stop];
+
+  self.session = [[AVCaptureSession alloc] init];
+
+  _displayID = displayID;
+  self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:displayID];
+  self.input.capturesCursor = NO;
+  [self.session addInput:self.input];
+
+  self.output = [[AVCaptureVideoDataOutput alloc] init];
+  self.output.videoSettings = @{
+    (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)
+  };
+  self.output.alwaysDiscardsLateVideoFrames = YES;
+  [self.session addOutput:self.output];
+  dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, DISPATCH_QUEUE_PRIORITY_HIGH);
+  self.sessionQueue = dispatch_queue_create("com.osxvnc.avscreencapture", queueAttributes);
+  [self.output setSampleBufferDelegate:self queue:self.sessionQueue];
+
+  [self.session startRunning];
+}
+
+- (void)stop
+{
+  if (nil == self.session) {
+    return;
+  }
+
+  [self.session stopRunning];
+  [self.session removeInput:self.input];
+  [self.input release];
+  self.input = nil;
+  [self.session removeOutput:self.output];
+  [self.output release];
+  self.output = nil;
+  [self.session release];
+  self.session = nil;
+}
+
+- (CMSampleBufferRef)lastFrame
+{
+  if (nil == self.session) {
+    return nil;
+  }
+
+  __block CMSampleBufferRef buffer = nil;
+  dispatch_sync(self.sessionQueue, ^{
+    buffer = self.sampleBufferHolder.sampleBuffer;
+    if (nil != buffer) {
+      CFRetain(buffer);
+    }
+  });
+  return buffer;
+}
+
+- (void)captureOutput:(AVCaptureOutput *)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection {
+    self.sampleBufferHolder.sampleBuffer = sampleBuffer;
+}
+
+@end

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -7,8 +7,11 @@
 //
 
 #import "AVScreenCapture.h"
+
 #import <AppKit/AppKit.h>
 #import "AVSampleBufferHolder.h"
+
+static const NSUInteger CAPTURE_FRAMES_PER_SECOND = 25;
 
 @interface AVScreenCapture() <AVCaptureVideoDataOutputSampleBufferDelegate>
 
@@ -16,7 +19,7 @@
 @property (nonatomic, retain, nullable) AVCaptureVideoDataOutput *output;
 @property (nonatomic, retain, nullable) AVCaptureScreenInput *input;
 @property (nonatomic, retain) AVSampleBufferHolder *sampleBufferHolder;
-@property dispatch_queue_t sessionQueue;
+@property (nonatomic) dispatch_queue_t sessionQueue;
 
 @end
 
@@ -66,6 +69,7 @@
   self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:self.displayID];
   self.input.capturesCursor = NO;
   self.input.scaleFactor = self.scaleFactor;
+  self.input.minFrameDuration = CMTimeMake(1, CAPTURE_FRAMES_PER_SECOND);
   [self.session addInput:self.input];
   self.output = [[AVCaptureVideoDataOutput alloc] init];
   self.output.videoSettings = @{

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -119,14 +119,12 @@
 
 - (BOOL)retrieveLastFrame:(IOSurfaceRef *)surface timestamp:(uint64_t *)timestamp
 {
-    if (nil == self.displayStream) {
+    if (nil == self.displayStream || nil == surface) {
         return NO;
     }
 
     @synchronized (self.sampleBufferHolder) {
-        if (surface) {
-            *surface = self.sampleBufferHolder.sampleBuffer;
-        }
+        *surface = self.sampleBufferHolder.sampleBuffer;
         if (timestamp) {
             *timestamp = self.sampleBufferHolder.timestamp;
         }

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -11,8 +11,9 @@
 #import <AppKit/AppKit.h>
 #import "AVSampleBufferHolder.h"
 
-static const int32_t MIN_FPS = 15;
-static const int32_t MAX_FPS = 60;
+const int32_t MIN_FPS = 15;
+const int32_t MAX_FPS = 60;
+const size_t BYTES_PER_PIXEL = 4;
 
 @interface AVScreenCapture() <AVCaptureVideoDataOutputSampleBufferDelegate>
 

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -67,7 +67,7 @@ static const NSUInteger CAPTURE_FRAMES_PER_SECOND = 25;
   self.session = [[AVCaptureSession alloc] init];
 
   self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:self.displayID];
-  self.input.capturesCursor = NO;
+  self.input.capturesCursor = YES;
   self.input.scaleFactor = self.scaleFactor;
   self.input.minFrameDuration = CMTimeMake(1, CAPTURE_FRAMES_PER_SECOND);
   [self.session addInput:self.input];

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -69,7 +69,7 @@ static const NSUInteger CAPTURE_FRAMES_PER_SECOND = 25;
   self.session = [[AVCaptureSession alloc] init];
 
   self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:self.displayID];
-  self.input.capturesCursor = YES;
+  self.input.capturesCursor = NO;
   self.input.scaleFactor = self.scaleFactor;
   self.input.minFrameDuration = CMTimeMake(1, CAPTURE_FRAMES_PER_SECOND);
   [self.session addInput:self.input];

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -1,5 +1,5 @@
 //
-//  AVScreenCapture.h
+//  AVScreenCapture.m
 //  OSXvnc
 //
 //  Created by Mykola Mokhnach on Mon Jan 14 2019.

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -74,14 +74,14 @@ const size_t BYTES_PER_PIXEL = 4;
         if (status != kCGDisplayStreamFrameStatusFrameComplete || !frameSurface || !updateRef) {
             return;
         }
-        @synchronized (self.sampleBufferHolder) {
-            self.sampleBufferHolder.sampleBuffer = frameSurface;
-            self.sampleBufferHolder.timestamp = displayTime;
-        }
         size_t count = 0;
         const CGRect* rects = CGDisplayStreamUpdateGetRects(updateRef, kCGDisplayStreamUpdateDirtyRects, &count);
         if (count > 0) {
             self.refreshCallback((uint32_t)count, rects, nil);
+        }
+        @synchronized (self.sampleBufferHolder) {
+            self.sampleBufferHolder.sampleBuffer = frameSurface;
+            self.sampleBufferHolder.timestamp = displayTime;
         }
     };
 

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -3,7 +3,7 @@
 //  OSXvnc
 //
 //  Created by Mykola Mokhnach on Mon Jan 14 2019.
-//  Copyright (c) 2019 Sauce Labds Inc. All rights reserved.
+//  Copyright (c) 2019 Sauce Labs Inc. All rights reserved.
 //
 
 #import "AVScreenCapture.h"
@@ -17,13 +17,13 @@
 @property (nonatomic, retain, nullable) AVCaptureScreenInput *input;
 @property (nonatomic, retain) AVSampleBufferHolder *sampleBufferHolder;
 @property dispatch_queue_t sessionQueue;
-@property CGFloat scaleFactor;
 
 @end
 
 @implementation AVScreenCapture
 
 @synthesize displayID = _displayID;
+@synthesize scaleFactor = _scaleFactor;
 
 - (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor
 {
@@ -74,7 +74,7 @@
   self.output.alwaysDiscardsLateVideoFrames = YES;
   [self.session addOutput:self.output];
   dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, DISPATCH_QUEUE_PRIORITY_HIGH);
-  self.sessionQueue = dispatch_queue_create("com.osxvnc.avscreencapture", queueAttributes);
+  self.sessionQueue = dispatch_queue_create("de.uni-mannheim.VineServer.avscreencapture", queueAttributes);
   [self.output setSampleBufferDelegate:self queue:self.sessionQueue];
 
   [self.session startRunning];

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -14,7 +14,7 @@
 
 @property (nonatomic, retain) AVSampleBufferHolder *sampleBufferHolder;
 @property (nonatomic) CGDisplayStreamRef displayStream;
-@property (nonatomic, readonly, assign) CGScreenRefreshCallback refreshCallback;
+@property (nonatomic, readonly) CGScreenRefreshCallback refreshCallback;
 @property (nonatomic, readonly, copy) NSMutableArray *fifo;
 
 @end

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -35,141 +35,142 @@ const size_t BYTES_PER_PIXEL = 4;
 
 - (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID scaleFactor:(CGFloat)scaleFactor
 {
-  if ((self = [super init])) {
-    _session = nil;
-    _output = nil;
-    _input = nil;
-    _sessionQueue = NULL;
-    _displayID = displayID;
-    _scaleFactor = scaleFactor;
-    _nextFrameSemaphore = NULL;
-    _isWaitingForNextFrame = NO;
-    _sampleBufferHolder = [[AVSampleBufferHolder alloc] init];
-  }
-  return self;
+    if ((self = [super init])) {
+        _session = nil;
+        _output = nil;
+        _input = nil;
+        _sessionQueue = NULL;
+        _displayID = displayID;
+        _scaleFactor = scaleFactor;
+        _nextFrameSemaphore = NULL;
+        _isWaitingForNextFrame = NO;
+        _sampleBufferHolder = [[AVSampleBufferHolder alloc] init];
+    }
+    return self;
 }
 
 - (void)dealloc {
-  [self stop];
+    [self stop];
 
-  [_sampleBufferHolder release];
-  _sampleBufferHolder = nil;
+    [_sampleBufferHolder release];
+    _sampleBufferHolder = nil;
 
-  if (NULL != _sessionQueue) {
-    dispatch_release(_sessionQueue);
-    _sessionQueue = NULL;
-  }
+    if (NULL != _sessionQueue) {
+        dispatch_release(_sessionQueue);
+        _sessionQueue = NULL;
+    }
 
-  [super dealloc];
+    [super dealloc];
 }
 
 - (void)startWithFps:(int32_t)fps
 {
-  if (nil != self.session) {
-    return;
-  }
+    if (nil != self.session) {
+        return;
+    }
 
-  [self stop];
+    [self stop];
 
-  self.session = [[AVCaptureSession alloc] init];
+    self.session = [[AVCaptureSession alloc] init];
 
-  self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:self.displayID];
-  self.input.capturesCursor = NO;
-  self.input.scaleFactor = self.scaleFactor;
-  self.input.minFrameDuration = CMTimeMake(1, MAX(MIN_FPS, MIN(fps, MAX_FPS)));
-  [self.session addInput:self.input];
-  self.output = [[AVCaptureVideoDataOutput alloc] init];
-  self.output.videoSettings = @{
-                                (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)
-                                };
-  self.output.alwaysDiscardsLateVideoFrames = YES;
-  [self.session addOutput:self.output];
-  dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, DISPATCH_QUEUE_PRIORITY_HIGH);
-  self.sessionQueue = dispatch_queue_create("de.uni-mannheim.VineServer.avscreencapture", queueAttributes);
-  [self.output setSampleBufferDelegate:self queue:self.sessionQueue];
+    self.input = [[AVCaptureScreenInput alloc] initWithDisplayID:self.displayID];
+    self.input.capturesCursor = NO;
+    self.input.scaleFactor = self.scaleFactor;
+    self.input.minFrameDuration = CMTimeMake(1, MAX(MIN_FPS, MIN(fps, MAX_FPS)));
+    [self.session addInput:self.input];
+    self.output = [[AVCaptureVideoDataOutput alloc] init];
+    self.output.videoSettings = @{
+                                  (id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA)
+                                  };
+    self.output.alwaysDiscardsLateVideoFrames = YES;
+    [self.session addOutput:self.output];
+    dispatch_queue_attr_t queueAttributes = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, DISPATCH_QUEUE_PRIORITY_HIGH);
+    self.sessionQueue = dispatch_queue_create("de.uni-mannheim.VineServer.avscreencapture", queueAttributes);
+    [self.output setSampleBufferDelegate:self queue:self.sessionQueue];
 
-  self.nextFrameSemaphore = dispatch_semaphore_create(0);
+    self.nextFrameSemaphore = dispatch_semaphore_create(0);
 
-  [self.session startRunning];
+    [self.session startRunning];
 }
 
 - (void)stop
 {
-  if (nil == self.session) {
-    return;
-  }
+    if (nil == self.session) {
+        return;
+    }
 
-  [self.session stopRunning];
-  [self.session removeInput:self.input];
-  [self.input release];
-  self.input = nil;
-  [self.session removeOutput:self.output];
-  [self.output release];
-  self.output = nil;
-  [self.session release];
-  self.session = nil;
+    [self.session stopRunning];
+    [self.session removeInput:self.input];
+    [self.input release];
+    self.input = nil;
+    [self.session removeOutput:self.output];
+    [self.output release];
+    self.output = nil;
+    [self.session release];
+    self.session = nil;
 
-  if (NULL != self.nextFrameSemaphore) {
-    dispatch_release(self.nextFrameSemaphore);
-    self.nextFrameSemaphore = NULL;
-  }
+    if (NULL != self.nextFrameSemaphore) {
+        dispatch_release(self.nextFrameSemaphore);
+        self.nextFrameSemaphore = NULL;
+    }
 }
 
 - (BOOL)retrieveLastFrame:(CMSampleBufferRef *)frame timestamp:(uint64_t *)timestamp
 {
-  if (nil == self.session) {
-    return NO;
-  }
-
-  __block CMSampleBufferRef buffer = nil;
-  __block uint64_t stamp = 0;
-  dispatch_sync(self.sessionQueue, ^{
-    buffer = self.sampleBufferHolder.sampleBuffer;
-    stamp = self.sampleBufferHolder.timestamp;
-    if (nil != buffer) {
-      CFRetain(buffer);
+    if (nil == self.session) {
+        return NO;
     }
-  });
-  if (nil == buffer) {
-    return NO;
-  }
 
-  *frame = buffer;
-  *timestamp = stamp;
-  return YES;
+    __block CMSampleBufferRef buffer = nil;
+    __block uint64_t stamp = 0;
+    dispatch_sync(self.sessionQueue, ^{
+        buffer = self.sampleBufferHolder.sampleBuffer;
+        stamp = self.sampleBufferHolder.timestamp;
+        if (nil != buffer) {
+            CFRetain(buffer);
+        }
+    });
+    if (nil == buffer) {
+        return NO;
+    }
+
+    *frame = buffer;
+    *timestamp = stamp;
+    return YES;
 }
 
 - (BOOL)retrieveNextFrame:(CMSampleBufferRef *)frame timestamp:(uint64_t *)timestamp timeout:(NSTimeInterval)timeout
 {
-  if (nil == self.session) {
-    return NO;
-  }
+    if (nil == self.session) {
+        return NO;
+    }
 
-  @synchronized (self) {
-    self.isWaitingForNextFrame = YES;
-  }
-  BOOL didFrameArrive = 0 == dispatch_semaphore_wait(self.nextFrameSemaphore,
-                                                     dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)));
-  @synchronized (self) {
-    self.isWaitingForNextFrame = NO;
-  }
-  if (!didFrameArrive) {
-    return NO;
-  }
+    @synchronized (self) {
+        self.isWaitingForNextFrame = YES;
+    }
+    BOOL didFrameArrive = 0 == dispatch_semaphore_wait(self.nextFrameSemaphore,
+                                                       dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)));
+    @synchronized (self) {
+        self.isWaitingForNextFrame = NO;
+    }
+    if (!didFrameArrive) {
+        return NO;
+    }
 
-  return [self retrieveLastFrame:frame timestamp:timestamp];
+    return [self retrieveLastFrame:frame timestamp:timestamp];
 }
 
 - (void)captureOutput:(AVCaptureOutput *)output
 didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
        fromConnection:(AVCaptureConnection *)connection {
-  self.sampleBufferHolder.sampleBuffer = sampleBuffer;
-  self.sampleBufferHolder.timestamp = mach_absolute_time();
-  @synchronized (self) {
-    if (self.isWaitingForNextFrame) {
-      dispatch_semaphore_signal(self.nextFrameSemaphore);
+    self.sampleBufferHolder.sampleBuffer = sampleBuffer;
+    self.sampleBufferHolder.timestamp = mach_absolute_time();
+    @synchronized (self) {
+        if (!self.isWaitingForNextFrame) {
+            return;
+        }
     }
-  }
+    dispatch_semaphore_signal(self.nextFrameSemaphore);
 }
 
 @end

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -117,7 +117,9 @@ static const NSUInteger CAPTURE_FRAMES_PER_SECOND = 25;
   return buffer;
 }
 
-- (void)captureOutput:(AVCaptureOutput *)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection {
+- (void)captureOutput:(AVCaptureOutput *)output
+didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+       fromConnection:(AVCaptureConnection *)connection {
     self.sampleBufferHolder.sampleBuffer = sampleBuffer;
 }
 

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -21,8 +21,6 @@
 
 @implementation AVScreenCapture
 
-@synthesize displayID = _displayID;
-
 - (instancetype)initWithDisplayID:(CGDirectDisplayID)displayID refreshCallback:(CGScreenRefreshCallback)refreshCallback
 {
     if ((self = [super init])) {

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -10,8 +10,6 @@
 
 #import "AVSampleBufferHolder.h"
 
-const size_t BYTES_PER_PIXEL = 4;
-
 @interface AVScreenCapture() <AVCaptureVideoDataOutputSampleBufferDelegate>
 
 @property (nonatomic, retain) AVSampleBufferHolder *sampleBufferHolder;
@@ -72,14 +70,14 @@ const size_t BYTES_PER_PIXEL = 4;
         if (status != kCGDisplayStreamFrameStatusFrameComplete || !frameSurface || !updateRef) {
             return;
         }
+        @synchronized (self.sampleBufferHolder) {
+            self.sampleBufferHolder.sampleBuffer = frameSurface;
+            self.sampleBufferHolder.timestamp = displayTime;
+        }
         size_t count = 0;
         const CGRect* rects = CGDisplayStreamUpdateGetRects(updateRef, kCGDisplayStreamUpdateDirtyRects, &count);
         if (count > 0) {
             self.refreshCallback((uint32_t)count, rects, nil);
-        }
-        @synchronized (self.sampleBufferHolder) {
-            self.sampleBufferHolder.sampleBuffer = frameSurface;
-            self.sampleBufferHolder.timestamp = displayTime;
         }
     };
 

--- a/OSXvnc-server/cutpaste.c
+++ b/OSXvnc-server/cutpaste.c
@@ -513,7 +513,7 @@ void rfbCheckForPasteboardChange() {
 		rfbClientIteratorPtr iterator = rfbGetClientIterator();
 
 		// Let's grab a copy of it here in the Main/Event Thread so that the output threads don't have to deal with the PB directly
-		if ([[NSPasteboard generalPasteboard] availableTypeFromArray:@[NSStringPboardType]]) {
+		if ([[NSPasteboard generalPasteboard].types containsObject:NSStringPboardType]) {
 			[pasteboardVariablesLock lock];
 			// Record first in case another event comes in after notifying clients
 			generalPBLastChangeCount = (int)[NSPasteboard generalPasteboard].changeCount;

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -580,40 +580,42 @@ static size_t frameBufferBitsPerPixel;
 char *rfbGetFramebuffer(void) {
     if (floor(NSAppKitVersionNumber) > floor(NSAppKitVersionNumber10_6)) {
         if (!frameBufferData) {
-            CGImageRef imageRef;
-            if (displayScale > 1.0) {
-                // Retina display.
-                size_t width = rfbScreen.width;
-                size_t height = rfbScreen.height;
-                CGImageRef image = CGDisplayCreateImage(displayID);
-                CGColorSpaceRef colorspace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
-                CGContextRef context = CGBitmapContextCreate(NULL, width, height,
-                                                             CGImageGetBitsPerComponent(image),
-                                                             CGImageGetBytesPerRow(image),
-                                                             colorspace,
-                                                             kCGImageAlphaNoneSkipLast);
-
-                CGColorSpaceRelease(colorspace);
-                if (context == NULL) {
-                    rfbLog("There was an error getting screen shot");
-                    return nil;
-                }
-                CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
-                imageRef = CGBitmapContextCreateImage(context);
-                CGContextRelease(context);
-                CGImageRelease(image);
-            } else {
-                imageRef = CGDisplayCreateImage(displayID);
-            }
-            CGDataProviderRef dataProvider = CGImageGetDataProvider (imageRef);
-            CFDataRef dataRef = CGDataProviderCopyData(dataProvider);
-            frameBufferBytesPerRow = CGImageGetBytesPerRow(imageRef);
-            frameBufferBitsPerPixel = CGImageGetBitsPerPixel(imageRef);
-            frameBufferData = [(NSData *)dataRef mutableCopy];
-            CFRelease(dataRef);
-
-            if (imageRef != NULL)
-                CGImageRelease(imageRef);
+            
+            
+//            CGImageRef imageRef;
+//            if (displayScale > 1.0) {
+//                // Retina display.
+//                size_t width = rfbScreen.width;
+//                size_t height = rfbScreen.height;
+//                CGImageRef image = CGDisplayCreateImage(displayID);
+//                CGColorSpaceRef colorspace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
+//                CGContextRef context = CGBitmapContextCreate(NULL, width, height,
+//                                                             CGImageGetBitsPerComponent(image),
+//                                                             CGImageGetBytesPerRow(image),
+//                                                             colorspace,
+//                                                             kCGImageAlphaNoneSkipLast);
+//
+//                CGColorSpaceRelease(colorspace);
+//                if (context == NULL) {
+//                    rfbLog("There was an error getting screen shot");
+//                    return nil;
+//                }
+//                CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
+//                imageRef = CGBitmapContextCreateImage(context);
+//                CGContextRelease(context);
+//                CGImageRelease(image);
+//            } else {
+//                imageRef = CGDisplayCreateImage(displayID);
+//            }
+//            CGDataProviderRef dataProvider = CGImageGetDataProvider (imageRef);
+//            CFDataRef dataRef = CGDataProviderCopyData(dataProvider);
+//            frameBufferBytesPerRow = CGImageGetBytesPerRow(imageRef);
+//            frameBufferBitsPerPixel = CGImageGetBitsPerPixel(imageRef);
+//            frameBufferData = [(NSData *)dataRef mutableCopy];
+//            CFRelease(dataRef);
+//
+//            if (imageRef != NULL)
+//                CGImageRelease(imageRef);
         }
         return frameBufferData.mutableBytes;
     }

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -299,7 +299,7 @@ void rfbCheckForScreenResolutionChange() {
                         // Reset Frame Buffer
                         free(cl->scalingFrameBuffer);
                         cl->scalingFrameBuffer = malloc( csw*csh*rfbScreen.bitsPerPixel/8 );
-                        cl->scalingPaddedWidthInBytes = csw * rfbScreen.bitsPerPixel/8;
+                        cl->scalingPaddedWidthInBytes = (int) (csw * rfbScreen.bitsPerPixel/8);
                     }
 
                     box.x1 = box.y1 = 0;
@@ -741,8 +741,8 @@ static bool rfbScreenInit(void) {
     vncScreenCapture = [[AVScreenCapture alloc] initWithDisplayID:displayID scaleFactor:1.0 / displayScale];
     [vncScreenCapture start];
 
-    rfbScreen.width = CGDisplayPixelsWide(displayID);
-    rfbScreen.height = CGDisplayPixelsHigh(displayID);
+    rfbScreen.width = (int) CGDisplayPixelsWide(displayID);
+    rfbScreen.height = (int) CGDisplayPixelsHigh(displayID);
     rfbScreen.bitsPerPixel = bitsPerPixelForDisplay(displayID);
     rfbScreen.depth = samplesPerPixel * bitsPerSample;
     //Fix for Yosemite and above
@@ -750,11 +750,11 @@ static bool rfbScreenInit(void) {
         // Let it collect a frame
         [NSThread sleepForTimeInterval:1.0f];
         CGImageRef imageRef = getRecentFrameImage();
-        rfbScreen.paddedWidthInBytes = CGImageGetBytesPerRow(imageRef);
+        rfbScreen.paddedWidthInBytes = (int) CGImageGetBytesPerRow(imageRef);
         if (nil != imageRef)
             CGImageRelease(imageRef);
     } else {
-        rfbScreen.paddedWidthInBytes = CGDisplayBytesPerRow(displayID);
+        rfbScreen.paddedWidthInBytes = (int) CGDisplayBytesPerRow(displayID);
     }
     rfbServerFormat.bitsPerPixel = rfbScreen.bitsPerPixel;
     rfbServerFormat.depth = rfbScreen.depth;

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -400,9 +400,7 @@ static void *clientOutput(void *data) {
             continue;
         }
 
-        if (timestamp == cl->previousFramebufferTimestamp
-            && cl->previousFramebufferDeliveryTimestamp > 0
-            && !cl->immediateUpdate) {
+        if (cl->previousFramebufferDeliveryTimestamp > 0 && !cl->immediateUpdate) {
             // Perform throttling to save the bandwidth
             uint64_t timeElapsed = mach_absolute_time() - cl->previousFramebufferDeliveryTimestamp;
             uint64_t nsElapsed = timeElapsed * timebaseInfo.numer / timebaseInfo.denom;
@@ -423,7 +421,6 @@ static void *clientOutput(void *data) {
         memcpy(cl->screenBuffer, frameData, dataLength);
         free(frameData);
         frameData = nil;
-        cl->previousFramebufferTimestamp = timestamp;
 
         /* Now, get the region we're going to update, and remove
          it from cl->modifiedRegion _before_ we send the update.

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -356,6 +356,7 @@ static void preprocessModifiedRegion(rfbClientPtr cl, char* currentFramebuffer, 
   const size_t VERTICAL_STEP = rfbScreen.height / VERTICAL_RECTS;
   const size_t bytesPerRow = rfbScreen.width * BYTES_PER_PIXEL;
   while (y < rfbScreen.height) {
+    x = 0;
     while (x < rfbScreen.width) {
       int gridX = x / HORIZONTAL_STEP;
       int gridY = y / VERTICAL_STEP;
@@ -367,9 +368,7 @@ static void preprocessModifiedRegion(rfbClientPtr cl, char* currentFramebuffer, 
       }
 
       size_t framebufferOffset = y * bytesPerRow + x * BYTES_PER_PIXEL;
-      BOOL isRectModified = 0 != memcmp(currentFramebuffer + framebufferOffset, previousFramebuffer + framebufferOffset, HORIZONTAL_STEP * BYTES_PER_PIXEL);
-
-      if (isRectModified) {
+      if (0 != memcmp(currentFramebuffer + framebufferOffset, previousFramebuffer + framebufferOffset, HORIZONTAL_STEP * BYTES_PER_PIXEL)) {
         RegionRec tmpRegion;
         BoxRec box;
         box.x1 = x;

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -330,7 +330,6 @@ void rfbCheckForScreenResolutionChange() {
 }
 
 static mach_timebase_info_data_t timebaseInfo;
-static NSTimeInterval timebaseSeconds;
 
 static void *clientOutput(void *data) {
     rfbClientPtr cl = (rfbClientPtr)data;
@@ -340,7 +339,6 @@ static void *clientOutput(void *data) {
     static dispatch_once_t onceStreamingInit;
     dispatch_once(&onceStreamingInit, ^{
         mach_timebase_info(&timebaseInfo);
-        timebaseSeconds = 1e-9 * (NSTimeInterval) timebaseInfo.numer / (NSTimeInterval) timebaseInfo.denom;
     });
 
     while (1) {

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -710,10 +710,10 @@ char *rfbGetFramebuffer(size_t *bufferLength) {
         char *frameData = rfbGetNextFrameData(&frameBufferLength, &timestamp, 2.0);
         if (nil != frameData) {
             frameBufferData = frameData;
-            if (bufferLength) {
-                *bufferLength = frameBufferLength;
-            }
         }
+    }
+    if (bufferLength) {
+        *bufferLength = frameBufferLength;
     }
     return frameBufferData;
 }

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -623,7 +623,7 @@ typedef struct {
     uint8_t green;
     uint8_t red;
     uint8_t alpha;
-} rgb_pixel_t;
+} pixel_t;
 // The incoming buffer is always BGRA32
 const size_t bufferBytesPerPixel = 4;
 
@@ -651,9 +651,9 @@ char *getRecentFrameData(CGRect cropRect, size_t *frameSize, size_t *bytesPerRow
         height = cropRect.size.height;
     }
     // Convert pixels from BGRA to RGB color space
-    const size_t pixelsLength = sizeof (rgb_pixel_t) * width * height;
-    rgb_pixel_t *rgbPixels = malloc(pixelsLength);
-    rgb_pixel_t *pixelOut = rgbPixels;
+    const size_t pixelsLength = sizeof (pixel_t) * width * height;
+    pixel_t *pixels = malloc(pixelsLength);
+    pixel_t *pixelOut = pixels;
     uint8_t *pixelIn;
     for (size_t y = top; y < top + height; y++) {
         for (size_t x = left; x < left + width; x++) {
@@ -670,11 +670,11 @@ char *getRecentFrameData(CGRect cropRect, size_t *frameSize, size_t *bytesPerRow
     CVPixelBufferUnlockBaseAddress(imageBuffer, 0);
     CFRelease(sampleBuffer);
     
-    *bytesPerRow = sizeof (rgb_pixel_t) * width;
-    *bitsPerPixel = sizeof (rgb_pixel_t) * 8;
+    *bytesPerRow = sizeof (pixel_t) * width;
+    *bitsPerPixel = sizeof (pixel_t) * 8;
     *frameSize = pixelsLength;
 
-    return (char *)rgbPixels;
+    return (char *)pixels;
 }
 
 char *rfbGetFramebuffer(void) {

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -702,7 +702,7 @@ void rfbGetFramebufferUpdateInRect(int x, int y, int w, int h) {
             source += imgBytesPerRow;
         }
 
-        if (imageRef != NULL)
+        if (nil != imageRef)
             CGImageRelease(imageRef);
         [(id)dataRef release];
     }

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -101,7 +101,7 @@ void * CGDisplayBaseAddress ( CGDirectDisplayID display );
 
 extern void rfbScreensaverTimer(EventLoopTimerRef timer, void *userData);
 
-int rfbDeferUpdateTime = 40; /* in ms */
+int rfbDeferUpdateTime = 1000 / DISPLAY_FPS; /* in ms */
 
 static char reverseHost[256] = "";
 static int reversePort = 5500;

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -725,8 +725,7 @@ static bool rfbScreenInit(void) {
     //Fix for Yosemite and above
     if (floor(NSAppKitVersionNumber) > floor(NSAppKitVersionNumber10_6)) {
         // Let it collect a frame
-        [NSThread sleepForTimeInterval:1.0f];
-        CMSampleBufferRef sampleBuffer = [vncScreenCapture lastFrame];
+        CMSampleBufferRef sampleBuffer = [vncScreenCapture frameWithTimeout:2.0];
         if (nil != sampleBuffer) {
             CVImageBufferRef imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
             CVPixelBufferLockBaseAddress(imageBuffer, 0);

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -405,6 +405,10 @@ static void *clientOutput(void *data) {
             frameData = rfbGetRecentFrameData(&frameDataLength, nil);
         }
         if (nil == frameData || referenceFramebufferLength != frameDataLength) {
+            if (nil != frameData) {
+                free(frameData);
+                frameData = nil;
+            }
             pthread_mutex_unlock(&cl->updateMutex);
             continue;
         }

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -338,7 +338,7 @@ static NSTimeInterval timebaseSeconds;
 static const NSTimeInterval REFERENCE_FRAME_INTERVAL = 0.4;
 // Force full screen update each X seconds to make sure there are
 // no synchronization artifacts on the remote screen
-static const NSTimeInterval FULL_SCREEN_REFRESH_INTERVAL = 2.0;
+static const NSTimeInterval FULL_SCREEN_REFRESH_INTERVAL = REFERENCE_FRAME_INTERVAL * 3;
 
 static Bool rfbShouldRefreshFullScreen(rfbClientPtr cl) {
     if (cl->previousFullScreenSyncTimestamp == cl->previousFramebufferDeliveryTimestamp) {

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -979,8 +979,6 @@ static void processArguments(int argc, char *argv[]) {
 void rfbShutdown(void) {
     [[VNCServer sharedServer] rfbShutdown];
 
-//    CGUnregisterScreenRefreshCallback(refreshCallback, NULL);
-    //CGDisplayShowCursor(displayID);
     rfbDimmingShutdown();
 
     rfbDebugLog("Removing Observers");
@@ -1224,16 +1222,11 @@ int main(int argc, char *argv[]) {
             if (!rfbClientsConnected()) {
                 pthread_mutex_lock(&listenerAccepting);
 
-                // You would think that there is no point in getting screen updates with no clients connected
-                // But it seems that unregistering but keeping the process (or event loop) around can cause a stuttering behavior in OS X.
+                rfbLog("Waiting for clients");
                 if (registered && unregisterWhenNoConnections) {
-                    rfbLog("UnRegistering screen update notification - waiting for clients");
-//                    CGUnregisterScreenRefreshCallback(refreshCallback, NULL);
                     [[VNCServer sharedServer] rfbDisconnect];
                     registered = NO;
                 }
-                else
-                    rfbLog("Waiting for clients");
 
                 pthread_cond_wait(&listenerGotNewClient, &listenerAccepting);
                 pthread_mutex_unlock(&listenerAccepting);

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -579,6 +579,7 @@ static NSMutableData *frameBufferData;
 static size_t frameBufferBytesPerRow;
 static size_t frameBufferBitsPerPixel;
 
+// this method is used for debug purposes
 BOOL CGImageWriteToFile(CGImageRef image, NSString *path) {
   CFURLRef url = (__bridge CFURLRef)[NSURL fileURLWithPath:path];
   CGImageDestinationRef destination = CGImageDestinationCreateWithURL(url, kUTTypePNG, 1, NULL);
@@ -630,7 +631,7 @@ CGImageRef getRecentFrameImage(void) {
   CGImageRef imageRef = CGBitmapContextCreateImage(context);
   CGContextRelease(context);
   CGImageRelease(image);
-  CGImageWriteToFile(imageRef, @"/Users/elf/Desktop/screen.png");
+//  CGImageWriteToFile(imageRef, @"/Users/elf/Desktop/screen.png");
   return imageRef;
 }
 
@@ -682,14 +683,8 @@ void rfbGetFramebufferUpdateInRect(int x, int y, int w, int h) {
           rfbLog("There was an error getting the screen shot");
           return;
         }
-        if (x + w > rfbScreen.width) {
-          w = (int)rfbScreen.width - x;
-        }
-        if (y + h > rfbScreen.height) {
-          h = (int)rfbScreen.height - y;
-        }
         CGImageRef imageRef = CGImageCreateWithImageInRect(fullImageRef, CGRectMake(x,y,w,h));
-        CGImageWriteToFile(imageRef, @"/Users/elf/Desktop/partial_screen.png");
+//        CGImageWriteToFile(imageRef, @"/Users/elf/Desktop/partial_screen.png");
         CGImageRelease(fullImageRef);
         CGDataProviderRef dataProvider = CGImageGetDataProvider(imageRef);
         CFDataRef dataRef = CGDataProviderCopyData(dataProvider);

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -718,10 +718,10 @@ static bool rfbScreenInit(void) {
         [vncScreenCapture release];
         vncScreenCapture = nil;
     }
-    vncScreenCapture = [[AVScreenCapture alloc] initWithDisplayID:displayID];
+    vncScreenCapture = [[AVScreenCapture alloc] initWithDisplayID:displayID
+                                                  refreshCallback:refreshCallback];
     [vncScreenCapture startWithWidth:rfbScreen.width
-                              height:rfbScreen.height
-                     refreshCallback:refreshCallback];
+                              height:rfbScreen.height];
 
     if (floor(NSAppKitVersionNumber) <= floor(NSAppKitVersionNumber10_6)) {
         rfbScreen.paddedWidthInBytes = (int) CGDisplayBytesPerRow(displayID);

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -445,6 +445,10 @@ static void *clientOutput(void *data) {
                 pthread_mutex_lock(&cl->updateMutex);
                 free(frameData);
                 frameData = rfbGetRecentFrameData(&dataLength, &timestamp);
+                if (nil == frameData || framebufferLength != dataLength) {
+                    pthread_mutex_unlock(&cl->updateMutex);
+                    continue;
+                }
             }
         }
 

--- a/OSXvnc-server/mousecursor.c
+++ b/OSXvnc-server/mousecursor.c
@@ -237,7 +237,8 @@ void rfbCheckForCursorChange() {
 	if (lastCursorSeed != currentSeed) {
         // Record first in case another change occurs after notifying clients
         lastCursorSeed = currentSeed;
-		loadCurrentCursorData();
+        // SAUCE: do not show the remote cursor (also crashes randomly)
+        // loadCurrentCursorData();
 		sendNotice = TRUE;
 	}
 	pthread_mutex_unlock(&cursorMutex);

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -321,6 +321,11 @@ typedef struct rfbClientRec {
 
     struct rfbClientRec *prev;
     struct rfbClientRec *next;
+
+    uint64_t previousFramebufferTimestamp;
+    uint64_t previousFramebufferDeliveryTimestamp;
+    uint64_t previousReferenceFramebufferTimestamp;
+    uint64_t referenceFramesCount;
 } rfbClientRec, *rfbClientPtr;
 
 

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -324,8 +324,6 @@ typedef struct rfbClientRec {
 
     uint64_t previousFramebufferTimestamp;
     uint64_t previousFramebufferDeliveryTimestamp;
-    uint64_t previousReferenceFramebufferTimestamp;
-    uint64_t previousFullScreenSyncTimestamp;
 } rfbClientRec, *rfbClientPtr;
 
 

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -54,12 +54,12 @@
 
 typedef struct
 {
-    int width;
-    int paddedWidthInBytes;
-    int height;
-    int depth;
-    int bitsPerPixel;
-    int sizeInBytes;
+    size_t width;
+    size_t paddedWidthInBytes;
+    size_t height;
+    size_t depth;
+    size_t bitsPerPixel;
+    size_t sizeInBytes;
 } rfbScreenInfo, *rfbScreenInfoPtr;
 
 

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -54,12 +54,12 @@
 
 typedef struct
 {
-    size_t width;
-    size_t paddedWidthInBytes;
-    size_t height;
-    size_t depth;
-    size_t bitsPerPixel;
-    size_t sizeInBytes;
+    int width;
+    int paddedWidthInBytes;
+    int height;
+    int depth;
+    int bitsPerPixel;
+    int sizeInBytes;
 } rfbScreenInfo, *rfbScreenInfoPtr;
 
 

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -373,7 +373,7 @@ extern unsigned rfbProtocolMinorVersion;
 extern unsigned rfbPort;
 
 extern char *rfbGetFramebuffer(void);
-extern void rfbGetFramebufferUpdateInRect(int x, int y, int w, int h);
+extern char *rfbGetRecentFrameData(size_t *dataLength);
 
 extern void rfbStartClientWithFD(int client_fd);
 extern void connectReverseClient(char *hostName, int portNum);

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -377,7 +377,7 @@ extern unsigned rfbProtocolMinorVersion;
 
 extern unsigned rfbPort;
 
-extern char *rfbGetFramebuffer(void);
+extern char *rfbGetFramebuffer(size_t *bufferLength);
 extern char *rfbGetRecentFrameData(size_t *dataLength, uint64_t *timestamp);
 
 extern void rfbStartClientWithFD(int client_fd);

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -373,7 +373,7 @@ extern unsigned rfbProtocolMinorVersion;
 extern unsigned rfbPort;
 
 extern char *rfbGetFramebuffer(void);
-extern char *rfbGetRecentFrameData(size_t *dataLength);
+extern char *rfbGetRecentFrameData(size_t *dataLength, uint64_t *timestamp);
 
 extern void rfbStartClientWithFD(int client_fd);
 extern void connectReverseClient(char *hostName, int portNum);

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -322,7 +322,6 @@ typedef struct rfbClientRec {
     struct rfbClientRec *prev;
     struct rfbClientRec *next;
 
-    uint64_t previousFramebufferTimestamp;
     uint64_t previousFramebufferDeliveryTimestamp;
 } rfbClientRec, *rfbClientPtr;
 

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -325,7 +325,7 @@ typedef struct rfbClientRec {
     uint64_t previousFramebufferTimestamp;
     uint64_t previousFramebufferDeliveryTimestamp;
     uint64_t previousReferenceFramebufferTimestamp;
-    uint64_t referenceFramesCount;
+    uint64_t previousFullScreenSyncTimestamp;
 } rfbClientRec, *rfbClientPtr;
 
 

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -273,7 +273,6 @@ rfbClientPtr rfbNewClient(int sock) {
     for (i = 0; i < 256; i++)
         cl->modiferKeys[i] = 0;
 
-    cl->previousFramebufferTimestamp = 0;
     cl->previousFramebufferDeliveryTimestamp = 0;
 
     box.x1 = box.y1 = 0;

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -1092,10 +1092,6 @@ Bool rfbSendFramebufferUpdate(rfbClientPtr cl, RegionRec updateRegion) {
         }
     }
 
-    cl->screenBuffer = rfbGetFramebuffer();
-
-    rfbGetFramebufferUpdateInRect(x, y, w, h);
-
     for (i = 0; i < REGION_NUM_RECTS(&updateRegion); i++) {
         uint32_t x = REGION_RECTS(&updateRegion)[i].x1;
         uint32_t y = REGION_RECTS(&updateRegion)[i].y1;

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -273,6 +273,11 @@ rfbClientPtr rfbNewClient(int sock) {
     for (i = 0; i < 256; i++)
         cl->modiferKeys[i] = 0;
 
+    cl->previousFramebufferTimestamp = 0;
+    cl->previousFramebufferDeliveryTimestamp = 0;
+    cl->previousReferenceFramebufferTimestamp = 0;
+    cl->referenceFramesCount = 0;
+
     box.x1 = box.y1 = 0;
     box.x2 = rfbScreen.width;
     box.y2 = rfbScreen.height;

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -316,7 +316,8 @@ rfbClientPtr rfbNewClient(int sock) {
 
     /* SERVER SCALING EXTENSIONS -- Server Scaling is off by default */
     cl->scalingFactor = 1;
-    cl->screenBuffer = rfbGetFramebuffer();
+    size_t bufferLength;
+    cl->screenBuffer = rfbGetFramebuffer(&bufferLength);
     cl->scalingFrameBuffer = cl->screenBuffer;
     cl->scalingPaddedWidthInBytes = rfbScreen.paddedWidthInBytes;
 

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -316,8 +316,7 @@ rfbClientPtr rfbNewClient(int sock) {
 
     /* SERVER SCALING EXTENSIONS -- Server Scaling is off by default */
     cl->scalingFactor = 1;
-    size_t bufferLength;
-    cl->screenBuffer = rfbGetFramebuffer(&bufferLength);
+    cl->screenBuffer = rfbGetFramebuffer(nil);
     cl->scalingFrameBuffer = cl->screenBuffer;
     cl->scalingPaddedWidthInBytes = rfbScreen.paddedWidthInBytes;
 

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -111,7 +111,6 @@ void rfbSendClientList() {
                                                                     object:[NSString stringWithFormat:@"OSXvnc%d",rfbPort]
                                                                   userInfo:@{@"clientList": clientList}];
 
-    [clientList dealloc];
     [pool release];
 
     pthread_mutex_unlock(&rfbClientListMutex);

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -276,7 +276,7 @@ rfbClientPtr rfbNewClient(int sock) {
     cl->previousFramebufferTimestamp = 0;
     cl->previousFramebufferDeliveryTimestamp = 0;
     cl->previousReferenceFramebufferTimestamp = 0;
-    cl->referenceFramesCount = 0;
+    cl->previousFullScreenSyncTimestamp = 0;
 
     box.x1 = box.y1 = 0;
     box.x2 = rfbScreen.width;

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -806,6 +806,7 @@ void rfbProcessClientNormalMessage(rfbClientPtr cl) {
             RegionRec tmpRegion;
             BoxRec box;
 
+            NSLog(@"Got update request");
             if ((n = ReadExact(cl, ((char *)&msg) + 1,
                                sz_rfbFramebufferUpdateRequestMsg-1)) <= 0) {
                 if (n != 0)
@@ -999,6 +1000,7 @@ void rfbProcessClientNormalMessage(rfbClientPtr cl) {
  */
 
 Bool rfbSendFramebufferUpdate(rfbClientPtr cl, RegionRec updateRegion) {
+    NSLog(@"Sending framebuffer");
     int i;
     uint32_t nUpdateRegionRects = 0;
     Bool sendRichCursorEncoding = FALSE;
@@ -1092,14 +1094,13 @@ Bool rfbSendFramebufferUpdate(rfbClientPtr cl, RegionRec updateRegion) {
 
     cl->screenBuffer = rfbGetFramebuffer();
 
+    rfbGetFramebufferUpdateInRect(x, y, w, h);
+
     for (i = 0; i < REGION_NUM_RECTS(&updateRegion); i++) {
         uint32_t x = REGION_RECTS(&updateRegion)[i].x1;
         uint32_t y = REGION_RECTS(&updateRegion)[i].y1;
         uint32_t w = REGION_RECTS(&updateRegion)[i].x2 - x;
         uint32_t h = REGION_RECTS(&updateRegion)[i].y2 - y;
-
-        rfbGetFramebufferUpdateInRect(x,y,w,h);
-
 
         // Refresh with latest pointer (should be "read-locked" throughout here with CG but I don't see that option)
         if (cl->scalingFactor != 1)

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -940,7 +940,7 @@ void rfbProcessClientNormalMessage(rfbClientPtr cl) {
                 }
                 else {
                     cl->scalingFrameBuffer = malloc( csw*csh*rfbScreen.bitsPerPixel/8 );
-                    cl->scalingPaddedWidthInBytes = csw * rfbScreen.bitsPerPixel/8;
+                    cl->scalingPaddedWidthInBytes = (int) (csw * rfbScreen.bitsPerPixel/8);
                 }
 
                 /* Now notify the client of the new desktop area */
@@ -1041,7 +1041,7 @@ Bool rfbSendFramebufferUpdate(rfbClientPtr cl, RegionRec updateRegion) {
             nUpdateRegionRects += n;
         }
     } else {
-        nUpdateRegionRects = REGION_NUM_RECTS(&updateRegion);
+        nUpdateRegionRects = (uint32_t) REGION_NUM_RECTS(&updateRegion);
     }
 
     // Sometimes send the mouse cursor update also

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -806,7 +806,6 @@ void rfbProcessClientNormalMessage(rfbClientPtr cl) {
             RegionRec tmpRegion;
             BoxRec box;
 
-            NSLog(@"Got update request");
             if ((n = ReadExact(cl, ((char *)&msg) + 1,
                                sz_rfbFramebufferUpdateRequestMsg-1)) <= 0) {
                 if (n != 0)
@@ -1000,7 +999,6 @@ void rfbProcessClientNormalMessage(rfbClientPtr cl) {
  */
 
 Bool rfbSendFramebufferUpdate(rfbClientPtr cl, RegionRec updateRegion) {
-    NSLog(@"Sending framebuffer");
     int i;
     uint32_t nUpdateRegionRects = 0;
     Bool sendRichCursorEncoding = FALSE;

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -275,8 +275,6 @@ rfbClientPtr rfbNewClient(int sock) {
 
     cl->previousFramebufferTimestamp = 0;
     cl->previousFramebufferDeliveryTimestamp = 0;
-    cl->previousReferenceFramebufferTimestamp = 0;
-    cl->previousFullScreenSyncTimestamp = 0;
 
     box.x1 = box.y1 = 0;
     box.x2 = rfbScreen.width;

--- a/OSXvnc.xcodeproj/project.pbxproj
+++ b/OSXvnc.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 
 /* Begin PBXBuildFile section */
 		13F8D24121ECDB1F007A9209 /* AVScreenCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 13F8D24021ECDB1F007A9209 /* AVScreenCapture.m */; };
+		713DBE9321F36C3300CC2EC3 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 713DBE9221F36C3300CC2EC3 /* CoreMedia.framework */; };
 		71FB44E421F343D100061CBA /* AVSampleBufferHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = 71FB44E321F343D100061CBA /* AVSampleBufferHolder.m */; };
 		71FB44E621F35D1D00061CBA /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71FB44E521F35D1D00061CBA /* AVFoundation.framework */; };
 		71FB44E821F35DCF00061CBA /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71FB44E721F35DCF00061CBA /* CoreVideo.framework */; };
@@ -146,6 +147,7 @@
 		13F8D23F21ECDB1F007A9209 /* AVScreenCapture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVScreenCapture.h; sourceTree = "<group>"; };
 		13F8D24021ECDB1F007A9209 /* AVScreenCapture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AVScreenCapture.m; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		713DBE9221F36C3300CC2EC3 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		71FB44E221F343D100061CBA /* AVSampleBufferHolder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVSampleBufferHolder.h; sourceTree = "<group>"; };
 		71FB44E321F343D100061CBA /* AVSampleBufferHolder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AVSampleBufferHolder.m; sourceTree = "<group>"; };
 		71FB44E521F35D1D00061CBA /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -285,6 +287,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				713DBE9321F36C3300CC2EC3 /* CoreMedia.framework in Frameworks */,
 				71FB44E821F35DCF00061CBA /* CoreVideo.framework in Frameworks */,
 				71FB44E621F35D1D00061CBA /* AVFoundation.framework in Frameworks */,
 				AB25D8AC0868707C0065843D /* Carbon.framework in Frameworks */,
@@ -351,6 +354,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				713DBE9221F36C3300CC2EC3 /* CoreMedia.framework */,
 				71FB44E721F35DCF00061CBA /* CoreVideo.framework */,
 				71FB44E521F35D1D00061CBA /* AVFoundation.framework */,
 				AB25DA3C086884420065843D /* libz.dylib */,

--- a/OSXvnc.xcodeproj/project.pbxproj
+++ b/OSXvnc.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 /* Begin PBXBuildFile section */
 		13F8D24121ECDB1F007A9209 /* AVScreenCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 13F8D24021ECDB1F007A9209 /* AVScreenCapture.m */; };
 		713DBE9321F36C3300CC2EC3 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 713DBE9221F36C3300CC2EC3 /* CoreMedia.framework */; };
+		71DD0BC52206F63E0091B9FF /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71DD0BC42206F63E0091B9FF /* IOSurface.framework */; };
 		71FB44E421F343D100061CBA /* AVSampleBufferHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = 71FB44E321F343D100061CBA /* AVSampleBufferHolder.m */; };
 		71FB44E621F35D1D00061CBA /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71FB44E521F35D1D00061CBA /* AVFoundation.framework */; };
 		71FB44E821F35DCF00061CBA /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71FB44E721F35DCF00061CBA /* CoreVideo.framework */; };
@@ -148,6 +149,7 @@
 		13F8D24021ECDB1F007A9209 /* AVScreenCapture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AVScreenCapture.m; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		713DBE9221F36C3300CC2EC3 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		71DD0BC42206F63E0091B9FF /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		71FB44E221F343D100061CBA /* AVSampleBufferHolder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVSampleBufferHolder.h; sourceTree = "<group>"; };
 		71FB44E321F343D100061CBA /* AVSampleBufferHolder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AVSampleBufferHolder.m; sourceTree = "<group>"; };
 		71FB44E521F35D1D00061CBA /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -287,6 +289,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71DD0BC52206F63E0091B9FF /* IOSurface.framework in Frameworks */,
 				713DBE9321F36C3300CC2EC3 /* CoreMedia.framework in Frameworks */,
 				71FB44E821F35DCF00061CBA /* CoreVideo.framework in Frameworks */,
 				71FB44E621F35D1D00061CBA /* AVFoundation.framework in Frameworks */,
@@ -354,6 +357,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				71DD0BC42206F63E0091B9FF /* IOSurface.framework */,
 				713DBE9221F36C3300CC2EC3 /* CoreMedia.framework */,
 				71FB44E721F35DCF00061CBA /* CoreVideo.framework */,
 				71FB44E521F35D1D00061CBA /* AVFoundation.framework */,

--- a/OSXvnc.xcodeproj/project.pbxproj
+++ b/OSXvnc.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		13F8D24121ECDB1F007A9209 /* AVScreenCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 13F8D24021ECDB1F007A9209 /* AVScreenCapture.m */; };
+		71FB44E421F343D100061CBA /* AVSampleBufferHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = 71FB44E321F343D100061CBA /* AVSampleBufferHolder.m */; };
+		71FB44E621F35D1D00061CBA /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71FB44E521F35D1D00061CBA /* AVFoundation.framework */; };
+		71FB44E821F35DCF00061CBA /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71FB44E721F35DCF00061CBA /* CoreVideo.framework */; };
 		9199995B0B1135FF0099EA7A /* getMACAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = 919999430B11348E0099EA7A /* getMACAddress.c */; };
 		AB25D81F08686B520065843D /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = F57BB467027E036F014B5D3F /* Credits.rtf */; };
 		AB25D82008686B520065843D /* Vine Server Release Notes.rtf in Resources */ = {isa = PBXBuildFile; fileRef = AB541C2907A0264F00B63668 /* Vine Server Release Notes.rtf */; };
@@ -139,7 +143,13 @@
 /* Begin PBXFileReference section */
 		096B69DC0097995A7F000001 /* OSXvnc.html */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text.html; path = OSXvnc.html; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		13F8D23F21ECDB1F007A9209 /* AVScreenCapture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVScreenCapture.h; sourceTree = "<group>"; };
+		13F8D24021ECDB1F007A9209 /* AVScreenCapture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AVScreenCapture.m; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		71FB44E221F343D100061CBA /* AVSampleBufferHolder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AVSampleBufferHolder.h; sourceTree = "<group>"; };
+		71FB44E321F343D100061CBA /* AVSampleBufferHolder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AVSampleBufferHolder.m; sourceTree = "<group>"; };
+		71FB44E521F35D1D00061CBA /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		71FB44E721F35DCF00061CBA /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
 		919999420B11348C0099EA7A /* getMACAddress.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = getMACAddress.h; sourceTree = "<group>"; };
 		919999430B11348E0099EA7A /* getMACAddress.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 30; path = getMACAddress.c; sourceTree = "<group>"; };
 		AB25D83708686B520065843D /* VineServer-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "VineServer-Info.plist"; sourceTree = "<group>"; };
@@ -275,6 +285,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71FB44E821F35DCF00061CBA /* CoreVideo.framework in Frameworks */,
+				71FB44E621F35D1D00061CBA /* AVFoundation.framework in Frameworks */,
 				AB25D8AC0868707C0065843D /* Carbon.framework in Frameworks */,
 				AB25D9400868707E0065843D /* Cocoa.framework in Frameworks */,
 				AB25DA3B0868842E0065843D /* IOKit.framework in Frameworks */,
@@ -339,6 +351,8 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				71FB44E721F35DCF00061CBA /* CoreVideo.framework */,
+				71FB44E521F35D1D00061CBA /* AVFoundation.framework */,
 				AB25DA3C086884420065843D /* libz.dylib */,
 				AB25DA3A0868842E0065843D /* IOKit.framework */,
 				ABF191B704E447A400A80117 /* Carbon.framework */,
@@ -369,6 +383,10 @@
 			isa = PBXGroup;
 			children = (
 				F538E10F02F9812C01A80186 /* Makefile */,
+				71FB44E221F343D100061CBA /* AVSampleBufferHolder.h */,
+				71FB44E321F343D100061CBA /* AVSampleBufferHolder.m */,
+				13F8D23F21ECDB1F007A9209 /* AVScreenCapture.h */,
+				13F8D24021ECDB1F007A9209 /* AVScreenCapture.m */,
 				F58DDDE7056A861001A8015E /* VNCServer.h */,
 				F58DDDE8056A861001A8015E /* VNCServer.m */,
 				ABA7B3D10948CB5D00CD7499 /* d3des.c */,
@@ -699,10 +717,12 @@
 				AB25D8A20868704E0065843D /* sockets.c in Sources */,
 				AB25D8A30868704F0065843D /* stats.c in Sources */,
 				AB25D8A5086870530065843D /* tight.c in Sources */,
+				13F8D24121ECDB1F007A9209 /* AVScreenCapture.m in Sources */,
 				AB25D8A6086870540065843D /* translate.c in Sources */,
 				AB25D8A7086870540065843D /* xalloc.c in Sources */,
 				AB25D8A8086870550065843D /* zlib.c in Sources */,
 				AB25D8A9086870550065843D /* zlibhex.c in Sources */,
+				71FB44E421F343D100061CBA /* AVSampleBufferHolder.m in Sources */,
 				AB25D8AA086870560065843D /* zrle.cc in Sources */,
 				ABA7B3D60948CB5D00CD7499 /* d3des.c in Sources */,
 				ABA7B3D70948CB5D00CD7499 /* vncauth.c in Sources */,
@@ -815,6 +835,8 @@
 				CODE_SIGN_IDENTITY = "";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				HEADER_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_NAME = "Vine Server Package";
 				SDKROOT = macosx;
 			};
@@ -826,6 +848,8 @@
 				CODE_SIGN_IDENTITY = "";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
+				HEADER_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = "";
 				PRODUCT_NAME = "Vine Server Package";
 				SDKROOT = macosx;
 			};
@@ -970,7 +994,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "";
 				INSTALL_PATH = "";
+				LIBRARY_SEARCH_PATHS = "";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -1009,7 +1035,9 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "";
 				INSTALL_PATH = "";
+				LIBRARY_SEARCH_PATHS = "";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;

--- a/VNCController.m
+++ b/VNCController.m
@@ -292,10 +292,17 @@ NSMutableArray *localIPAddresses() {
                 [ipString replaceCharactersInRange:NSMakeRange(ipString.length,0) withString:@"\tInternal"];
             }
 
-            if (controller && !limitToLocalConnections.state) { // Colorize and add tooltip
+            __block BOOL islimitToLocalConnectionsEnabled;
+            __block int runningPortNum;
+            dispatch_sync(dispatch_get_main_queue(), ^{
+              islimitToLocalConnectionsEnabled = limitToLocalConnections.state;
+              runningPortNum = self.runningPortNum;
+            });
+
+            if (controller && !islimitToLocalConnectionsEnabled) { // Colorize and add tooltip
 
                 NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%d",
-                                                       anIP, self.runningPortNum]];
+                                                       anIP, runningPortNum]];
                 NSData *testData = [NSData dataWithContentsOfURL:testURL];
                 NSString *testString = (testData.length
                                         ? [NSString stringWithUTF8String: testData.bytes] : @"");


### PR DESCRIPTION
I've tested the changed server and the original one built from master and a significant improvement in FPS performance can be observed. Full screen video plays at 25-30 FPS, windowed - 12-25 FPS. 

~~Although, the normal interaction with the mouse cursor has a tiny lag. I don't think this could be easily workarounded, since the captured video frames are already delayed from what is happening in real time.~~

This was fixed after switching to `CGDisplayStream`