### PR TITLE
Hide server-side mouse cursor to avoid laggy experience on the customer side

### DIFF
--- a/OSXvnc-server/CGS.h
+++ b/OSXvnc-server/CGS.h
@@ -15,6 +15,7 @@ typedef int CGSConnectionRef;
 
 extern CGError CGSNewConnection(void* unknown, CGSConnectionRef* newConnection);
 extern CGError CGSReleaseConnection(CGSConnectionRef connection);
+extern void CGSSetConnectionProperty(int conn, int conn2, CFStringRef propertyName, CFBooleanRef propertyValue);
 
 extern CGError CGSGetGlobalCursorDataSize(CGSConnectionRef connection, int* size);
 extern CGError CGSGetGlobalCursorData(CGSConnectionRef connection,
@@ -26,6 +27,8 @@ extern CGError CGSGetGlobalCursorData(CGSConnectionRef connection,
                                       int* depth,
                                       int* components,
                                       int* bitsPerComponent);
+
+extern int _CGSDefaultConnection(void);
 
 extern CGError CGSGetCurrentCursorLocation(CGSConnectionRef connection, CGPoint* point);
 extern int CGSCurrentCursorSeed(void);

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1209,8 +1209,14 @@ int main(int argc, char *argv[]) {
         OSStatus resultCode = 0;
 
         while (keepRunning) {
-            // No Clients - go into hibernation
-            if (!rfbClientsConnected()) {
+            if (rfbClientsConnected()) {
+                // SAUCE: The cursor is automatically restored if moved over the Dock
+                // Make sure it is hidden on each event loop
+                rfbSetCursorVisibility(FALSE);
+            } else {
+                // Show the cursor back if no clients are connected
+                rfbSetCursorVisibility(TRUE);
+                // No Clients - go into hibernation
                 pthread_mutex_lock(&listenerAccepting);
 
                 rfbLog("Waiting for clients");

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1212,10 +1212,10 @@ int main(int argc, char *argv[]) {
             if (rfbClientsConnected()) {
                 // SAUCE: The cursor is automatically restored if moved over the Dock
                 // Make sure it is hidden on each event loop
-                rfbSetCursorVisibility(FALSE);
+                rfbSetCursorVisibility(FALSE, displayID);
             } else {
                 // Show the cursor back if no clients are connected
-                rfbSetCursorVisibility(TRUE);
+                rfbSetCursorVisibility(TRUE, displayID);
                 // No Clients - go into hibernation
                 pthread_mutex_lock(&listenerAccepting);
 

--- a/OSXvnc-server/mousecursor.c
+++ b/OSXvnc-server/mousecursor.c
@@ -68,14 +68,14 @@ CGPoint currentCursorLoc() {
     return cursorLoc;
 }
 
-void setCursorVisibility(Bool isVisible) {
+void setCursorVisibility(Bool isVisible, CGDirectDisplayID displayID) {
     CFStringRef propertyString = CFStringCreateWithCString(NULL, "SetsCursorInBackground", kCFStringEncodingUTF8);
     CGSSetConnectionProperty(_CGSDefaultConnection(), _CGSDefaultConnection(), propertyString, isVisible ? kCFBooleanFalse : kCFBooleanTrue);
     CFRelease(propertyString);
     if (isVisible) {
-        CGDisplayShowCursor(kCGDirectMainDisplay);
+        CGDisplayShowCursor(displayID);
     } else {
-        CGDisplayHideCursor(kCGDirectMainDisplay);
+        CGDisplayHideCursor(displayID);
     }
 }
 
@@ -111,8 +111,8 @@ void loadCurrentCursorData() {
     //CGSReleaseConnection(connection);
     if (err != kCGErrorSuccess) {
         // `free` is most likely called automatically if an error happens
-		// free(cursorData);
-		cursorData = NULL;
+        // free(cursorData);
+        cursorData = NULL;
         rfbLog("Error obtaining cursor data - cursor not sent");
         return;
     }
@@ -130,7 +130,7 @@ void loadCurrentCursorData() {
     cursorMaskSize = floor((cursorRect.size.width+7)/8) * cursorRect.size.height;
 
     if (cursorMaskData) {
-		free(cursorMaskData);
+        free(cursorMaskData);
         cursorMaskData = NULL;
     }
 	cursorMaskData = (unsigned char*)malloc(sizeof(unsigned char) * cursorMaskSize);
@@ -282,8 +282,8 @@ Bool rfbShouldSendNewCursor(rfbClientPtr cl) {
         return (cl->currentCursorSeed != lastCursorSeed);
 }
 
-void rfbSetCursorVisibility(Bool isVisible) {
-    setCursorVisibility(isVisible);
+void rfbSetCursorVisibility(Bool isVisible, CGDirectDisplayID displayID) {
+    setCursorVisibility(isVisible, displayID);
 }
 
 Bool rfbShouldSendNewPosition(rfbClientPtr cl) {

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -44,6 +44,7 @@
 //#include <ApplicationServices/ApplicationServices.h>
 
 #include "CoreGraphics/CGGeometry.h"
+#include "CoreGraphics/CGDirectDisplay.h"
 
 #define MAX_ENCODINGS 17
 

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -615,6 +615,7 @@ extern void GetCursorInfo(void);
 extern void rfbCheckForCursorChange(void);
 extern Bool rfbShouldSendNewCursor(rfbClientPtr cl);
 extern Bool rfbShouldSendNewPosition(rfbClientPtr cl);
+extern void rfbSetCursorVisibility(Bool isVisible);
 
 extern Bool rfbSendRichCursorUpdate(rfbClientPtr cl);
 extern Bool rfbSendCursorPos(rfbClientPtr cl);

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -615,7 +615,7 @@ extern void GetCursorInfo(void);
 extern void rfbCheckForCursorChange(void);
 extern Bool rfbShouldSendNewCursor(rfbClientPtr cl);
 extern Bool rfbShouldSendNewPosition(rfbClientPtr cl);
-extern void rfbSetCursorVisibility(Bool isVisible);
+extern void rfbSetCursorVisibility(Bool isVisible, CGDirectDisplayID displayID);
 
 extern Bool rfbSendRichCursorUpdate(rfbClientPtr cl);
 extern Bool rfbSendCursorPos(rfbClientPtr cl);


### PR DESCRIPTION
The implementation uses `CGS` hacks in order to manipulate the mouse cursor from a background app.