### PR TITLE
Properly calculate bytes padding for different screen resolutions

### DIFF
--- a/OSXvnc-server/AVScreenCapture.h
+++ b/OSXvnc-server/AVScreenCapture.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)retrieveLastFrame:(char **)frameData
                dataLength:(nullable size_t *)dataLength
                 timestamp:(nullable uint64_t *)timestamp;
+- (size_t)paddedScreenWidthWithTimeout:(NSTimeInterval)timeout;
 - (void)stop;
 
 @end

--- a/OSXvnc-server/AVScreenCapture.m
+++ b/OSXvnc-server/AVScreenCapture.m
@@ -193,7 +193,7 @@
         return 0;
     }
     
-    size_t secondsElapsed = 0;
+    NSTimeInterval secondsElapsed = 0.0;
     IOSurfaceRef surface = nil;
     do {
         @synchronized (self.sampleBufferHolder) {
@@ -205,7 +205,7 @@
             }
         }
         RunCurrentEventLoop(kEventDurationSecond);
-        secondsElapsed++;
+        secondsElapsed += kEventDurationSecond;
     } while (secondsElapsed < timeout + DBL_EPSILON);
     if (nil == surface) {
         return 0;

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -660,7 +660,6 @@ static bool rfbScreenInit(void) {
     rfbScreen.height = (int) CGDisplayPixelsHigh(displayID);
     rfbScreen.bitsPerPixel = bitsPerPixelForDisplay(displayID);
     rfbScreen.depth = samplesPerPixel * bitsPerSample;
-    rfbScreen.paddedWidthInBytes = (int) (rfbScreen.width * BYTES_PER_PIXEL);
 
     if (nil != vncScreenCapture) {
         [vncScreenCapture stop];
@@ -674,6 +673,14 @@ static bool rfbScreenInit(void) {
 
     if (floor(NSAppKitVersionNumber) <= floor(NSAppKitVersionNumber10_6)) {
         rfbScreen.paddedWidthInBytes = (int) CGDisplayBytesPerRow(displayID);
+    } else {
+        size_t paddedWidthInBytes = [vncScreenCapture paddedScreenWidthWithTimeout:3];
+        if (0 == paddedWidthInBytes) {
+            rfbLog("Could not retrieve padded screen width");
+            rfbScreen.paddedWidthInBytes = BYTES_PER_PIXEL * rfbScreen.width;
+        } else {
+            rfbScreen.paddedWidthInBytes = (int) paddedWidthInBytes;
+        }
     }
     rfbServerFormat.bitsPerPixel = rfbScreen.bitsPerPixel;
     rfbServerFormat.depth = rfbScreen.depth;


### PR DESCRIPTION
It looks like Mac OS Window Manager pads the rows of the screen bitmap with extra bytes for some particular screen resolutions. This PR fixes OSXVnc, so it can properly display the picture for such resolutions.