### PR TITLE
Only refresh the cursor state after some reasonable time interval

### DIFF
--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1101,10 +1101,7 @@ BOOL runningLittleEndian ( void ) {
 
 int main(int argc, char *argv[]) {
     NSAutoreleasePool *tempPool = [[NSAutoreleasePool alloc] init];
-    static dispatch_once_t onceStreamingInit;
-    dispatch_once(&onceStreamingInit, ^{
-        mach_timebase_info(&timebaseInfo);
-    });
+    mach_timebase_info(&timebaseInfo);
     vncServerObject = [[VNCServer alloc] init];
     littleEndian = runningLittleEndian();
     checkForUsage(argc,argv);

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1209,7 +1209,6 @@ int main(int argc, char *argv[]) {
     // This segment is what is responsible for causing the server to shutdown when a user logs out
     // The problem being that OS X sends it first a SIGTERM and then a SIGKILL (un-trappable)
     // Presumable because it's running a Carbon Event loop
-    const NSTimeInterval cursorVisibilityRefreshInterval = 5;
     if (1) {
         OSStatus resultCode = 0;
 
@@ -1221,7 +1220,7 @@ int main(int argc, char *argv[]) {
                 Bool shouldSyncCursorVisibility = 0 == lastCursorVisibilitySync;
                 if (lastCursorVisibilitySync > 0) {
                     uint64_t nsElapsed = (mach_absolute_time() - lastCursorVisibilitySync) * timebaseInfo.numer / timebaseInfo.denom;
-                    shouldSyncCursorVisibility = 1.0 * nsElapsed / NSEC_PER_SEC >= cursorVisibilityRefreshInterval;
+                    shouldSyncCursorVisibility = 1.0 * nsElapsed / NSEC_PER_SEC >= 1.0;
                 }
                 if (shouldSyncCursorVisibility) {
                     rfbSetCursorVisibility(FALSE);

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1221,12 +1221,12 @@ int main(int argc, char *argv[]) {
             if (rfbClientsConnected()) {
                 // SAUCE: The cursor is automatically restored if moved over the Dock
                 // Make sure it is hidden every `cursorVisibilityRefreshInterval` seconds
-                Bool shouldSyncCursorVisibilty = 0 == lastCursorVisibilitySync;
+                Bool shouldSyncCursorVisibility = 0 == lastCursorVisibilitySync;
                 if (lastCursorVisibilitySync > 0) {
                     uint64_t nsElapsed = (mach_absolute_time() - lastCursorVisibilitySync) * timebaseInfo.numer / timebaseInfo.denom;
-                    shouldSyncCursorVisibilty = 1.0 * nsElapsed / NSEC_PER_SEC >= cursorVisibilityRefreshInterval;
+                    shouldSyncCursorVisibility = 1.0 * nsElapsed / NSEC_PER_SEC >= cursorVisibilityRefreshInterval;
                 }
-                if (shouldSyncCursorVisibilty) {
+                if (shouldSyncCursorVisibility) {
                     rfbSetCursorVisibility(FALSE);
                     lastCursorVisibilitySync = mach_absolute_time();
                 }

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1220,7 +1220,7 @@ int main(int argc, char *argv[]) {
                 Bool shouldSyncCursorVisibility = 0 == lastCursorVisibilitySync;
                 if (lastCursorVisibilitySync > 0) {
                     uint64_t nsElapsed = (mach_absolute_time() - lastCursorVisibilitySync) * timebaseInfo.numer / timebaseInfo.denom;
-                    shouldSyncCursorVisibility = 1.0 * nsElapsed / NSEC_PER_SEC >= 1.0;
+                    shouldSyncCursorVisibility = 1.0 * nsElapsed / NSEC_PER_SEC >= 0.5;
                 }
                 if (shouldSyncCursorVisibility) {
                     rfbSetCursorVisibility(FALSE);

--- a/OSXvnc-server/main.c
+++ b/OSXvnc-server/main.c
@@ -1221,12 +1221,10 @@ int main(int argc, char *argv[]) {
             if (rfbClientsConnected()) {
                 // SAUCE: The cursor is automatically restored if moved over the Dock
                 // Make sure it is hidden every `cursorVisibilityRefreshInterval` seconds
-                Bool shouldSyncCursorVisibilty = FALSE;
+                Bool shouldSyncCursorVisibilty = 0 == lastCursorVisibilitySync;
                 if (lastCursorVisibilitySync > 0) {
                     uint64_t nsElapsed = (mach_absolute_time() - lastCursorVisibilitySync) * timebaseInfo.numer / timebaseInfo.denom;
                     shouldSyncCursorVisibilty = 1.0 * nsElapsed / NSEC_PER_SEC >= cursorVisibilityRefreshInterval;
-                } else {
-                    shouldSyncCursorVisibilty = TRUE;
                 }
                 if (shouldSyncCursorVisibilty) {
                     rfbSetCursorVisibility(FALSE);

--- a/OSXvnc-server/mousecursor.c
+++ b/OSXvnc-server/mousecursor.c
@@ -73,8 +73,10 @@ void setCursorVisibility(Bool isVisible) {
     CGSSetConnectionProperty(_CGSDefaultConnection(), _CGSDefaultConnection(), propertyString, isVisible ? kCFBooleanFalse : kCFBooleanTrue);
     CFRelease(propertyString);
     if (isVisible) {
+        CGDisplayHideCursor(0);
         CGDisplayShowCursor(0);
     } else {
+        CGDisplayShowCursor(0);
         CGDisplayHideCursor(0);
     }
 }

--- a/OSXvnc-server/mousecursor.c
+++ b/OSXvnc-server/mousecursor.c
@@ -73,11 +73,10 @@ void setCursorVisibility(Bool isVisible) {
     CGSSetConnectionProperty(_CGSDefaultConnection(), _CGSDefaultConnection(), propertyString, isVisible ? kCFBooleanFalse : kCFBooleanTrue);
     CFRelease(propertyString);
     if (isVisible) {
-        CGDisplayShowCursor(displayID);
+        CGDisplayShowCursor(0);
     } else {
-        CGDisplayHideCursor(displayID);
+        CGDisplayHideCursor(0);
     }
-
 }
 
 void loadCurrentCursorData() {

--- a/OSXvnc-server/mousecursor.c
+++ b/OSXvnc-server/mousecursor.c
@@ -19,7 +19,7 @@
 
 #include "CGS.h"
 
-static int lastCursorSeed = 0;
+static int lastCursorSeed = -1;
 static int maxFailsRemaining = 8;
 static CGPoint lastCursorPosition;
 
@@ -73,10 +73,8 @@ void setCursorVisibility(Bool isVisible) {
     CGSSetConnectionProperty(_CGSDefaultConnection(), _CGSDefaultConnection(), propertyString, isVisible ? kCFBooleanFalse : kCFBooleanTrue);
     CFRelease(propertyString);
     if (isVisible) {
-        CGDisplayHideCursor(0);
         CGDisplayShowCursor(0);
     } else {
-        CGDisplayShowCursor(0);
         CGDisplayHideCursor(0);
     }
 }

--- a/OSXvnc-server/mousecursor.c
+++ b/OSXvnc-server/mousecursor.c
@@ -243,35 +243,30 @@ void GetCursorInfo() {
 // We call this to see if we have a new cursor and should notify clients to do an update
 // Or if cursor has moved
 void rfbCheckForCursorChange() {
-	Bool sendNotice = FALSE;
     CGPoint cursorLoc = currentCursorLoc();
 	int currentSeed = CGSCurrentCursorSeed();
 
 	pthread_mutex_lock(&cursorMutex);
 	if (!CGPointEqualToPoint(lastCursorPosition, cursorLoc)) {
 		lastCursorPosition = cursorLoc;
-		sendNotice = TRUE;
 	}
 	if (lastCursorSeed != currentSeed) {
         // Record first in case another change occurs after notifying clients
         lastCursorSeed = currentSeed;
         loadCurrentCursorData();
-		sendNotice = TRUE;
 	}
 	pthread_mutex_unlock(&cursorMutex);
 
     //rfbLog("Check For Cursor Change");
-    if (sendNotice) {
-        rfbClientIteratorPtr iterator = rfbGetClientIterator();
-        rfbClientPtr cl;
+    rfbClientIteratorPtr iterator = rfbGetClientIterator();
+    rfbClientPtr cl;
 
-        // Notify each client
-        while ((cl = rfbClientIteratorNext(iterator)) != NULL) {
-            if (rfbShouldSendNewCursor(cl) || (rfbShouldSendNewPosition(cl)))
-                pthread_cond_signal(&cl->updateCond);
-        }
-        rfbReleaseClientIterator(iterator);
+    // Notify each client
+    while ((cl = rfbClientIteratorNext(iterator)) != NULL) {
+        if (rfbShouldSendNewCursor(cl) || (rfbShouldSendNewPosition(cl)))
+            pthread_cond_signal(&cl->updateCond);
     }
+    rfbReleaseClientIterator(iterator);
 }
 
 #pragma mark -

--- a/OSXvnc-server/mousecursor.c
+++ b/OSXvnc-server/mousecursor.c
@@ -68,7 +68,7 @@ CGPoint currentCursorLoc() {
     return cursorLoc;
 }
 
-void setCursorVisibility(Bool isVisible, CGDirectDisplayID displayID) {
+void setCursorVisibility(Bool isVisible) {
     CFStringRef propertyString = CFStringCreateWithCString(NULL, "SetsCursorInBackground", kCFStringEncodingUTF8);
     CGSSetConnectionProperty(_CGSDefaultConnection(), _CGSDefaultConnection(), propertyString, isVisible ? kCFBooleanFalse : kCFBooleanTrue);
     CFRelease(propertyString);
@@ -77,6 +77,7 @@ void setCursorVisibility(Bool isVisible, CGDirectDisplayID displayID) {
     } else {
         CGDisplayHideCursor(displayID);
     }
+
 }
 
 void loadCurrentCursorData() {
@@ -282,8 +283,8 @@ Bool rfbShouldSendNewCursor(rfbClientPtr cl) {
         return (cl->currentCursorSeed != lastCursorSeed);
 }
 
-void rfbSetCursorVisibility(Bool isVisible, CGDirectDisplayID displayID) {
-    setCursorVisibility(isVisible, displayID);
+void rfbSetCursorVisibility(Bool isVisible) {
+    setCursorVisibility(isVisible);
 }
 
 Bool rfbShouldSendNewPosition(rfbClientPtr cl) {

--- a/OSXvnc-server/rfb.h
+++ b/OSXvnc-server/rfb.h
@@ -616,7 +616,7 @@ extern void GetCursorInfo(void);
 extern void rfbCheckForCursorChange(void);
 extern Bool rfbShouldSendNewCursor(rfbClientPtr cl);
 extern Bool rfbShouldSendNewPosition(rfbClientPtr cl);
-extern void rfbSetCursorVisibility(Bool isVisible, CGDirectDisplayID displayID);
+extern void rfbSetCursorVisibility(Bool isVisible);
 
 extern Bool rfbSendRichCursorUpdate(rfbClientPtr cl);
 extern Bool rfbSendCursorPos(rfbClientPtr cl);

--- a/OSXvnc-server/rfbserver.c
+++ b/OSXvnc-server/rfbserver.c
@@ -739,7 +739,7 @@ void rfbProcessClientNormalMessage(rfbClientPtr cl) {
                     case rfbEncodingRichCursor:
                         rfbLog("\tEnabling Cursor Shape protocol extension for client %s", cl->host);
                         cl->useRichCursorEncoding = TRUE;
-                        cl->currentCursorSeed = 0;
+                        cl->currentCursorSeed = -1;
                         break;
                     case rfbEncodingPointerPos:
                         rfbLog("\tEnabling Cursor Position protocol extension for client %s", cl->host);


### PR DESCRIPTION
Constantly calling HideCursor API in the events loop causes Chrome to go crazy. And since MacOS does not provide a reliable way to check the cursor visibility we simply delay cursor refresh to be triggered once per 5 seconds as a workaround.